### PR TITLE
Subscription logic

### DIFF
--- a/lib/api/slack.ex
+++ b/lib/api/slack.ex
@@ -1,4 +1,3 @@
-require IEx
 defmodule Aprb.Api.Slack do
   use Maru.Router
   import Ecto.Query

--- a/lib/event_receiver.ex
+++ b/lib/event_receiver.ex
@@ -1,18 +1,19 @@
-require IEx
 defmodule Aprb.EventReceiver do
   require Logger
+  alias Aprb.{Repo, Topic}
 
   def start_link(channel) do
     KafkaEx.create_worker(String.to_atom(channel))
     for message <- KafkaEx.stream(channel, 0, worker_name: String.to_atom(channel), offset: latest_offset(channel)), acceptable_message?(message.value) do
       proccessed_message = process_message(message, channel)
       # broadcast a message to a channel
-      IO.puts proccessed_message
-      t = Slack.Web.Chat.post_message("#apr-machines", proccessed_message)
+      for subscriber <- get_topic_subscribers(channel) do
+        Slack.Web.Chat.post_message("##{subscriber.channel_name}", proccessed_message)
+      end
     end
   end
 
-  def latest_offset(channel) do
+  defp latest_offset(channel) do
     KafkaEx.latest_offset(channel, 0)
         |> List.first
         |> Map.get(:partition_offsets)
@@ -21,7 +22,7 @@ defmodule Aprb.EventReceiver do
         |> List.first
   end
 
-  def acceptable_message?(message) do
+  defp acceptable_message?(message) do
     try do
       Poison.decode!(message)
         |> is_map
@@ -30,7 +31,7 @@ defmodule Aprb.EventReceiver do
     end
   end
 
-  def process_message(message, channel) do
+  defp process_message(message, channel) do
     event = Poison.decode!(message.value)
     case channel do
       "users" ->
@@ -40,5 +41,11 @@ defmodule Aprb.EventReceiver do
       "inquiries" ->
         ":shaka: #{event["subject"]["display"]} #{event["verb"]} #{event["properties"]["inquireable"]["name"]}"
     end
+  end
+
+  defp get_topic_subscribers(topic_name) do
+    topic = Repo.get_by(Topic, name: topic_name)
+              |> Repo.preload(:subscribers)
+    topic.subscribers
   end
 end

--- a/lib/models/subscriber.ex
+++ b/lib/models/subscriber.ex
@@ -23,6 +23,6 @@ defmodule Aprb.Subscriber do
   def changeset(model, params \\ :empty) do
     model
     |> cast(params, @required_fields, @optional_fields)
-    |> unique_constraint(:user_id)
+    |> unique_constraint(:channel_id)
   end
 end

--- a/lib/models/subscription.ex
+++ b/lib/models/subscription.ex
@@ -6,7 +6,6 @@ defmodule Aprb.Subscription do
     belongs_to :topic, Aprb.Topic
     belongs_to :subscriber, Aprb.Subscriber
 
-    timestamps
   end
 
   @required_fields ~w(topic_id subscriber_id)

--- a/lib/models/topic.ex
+++ b/lib/models/topic.ex
@@ -6,7 +6,7 @@ defmodule Aprb.Topic do
     field :name, :string
 
     has_many :subscriptions, Aprb.Subscription
-    has_many :users, through: [:subscriptions, :user]
+    has_many :subscribers, through: [:subscriptions, :subscriber]
 
     timestamps
   end

--- a/test/api/slack_test.exs
+++ b/test/api/slack_test.exs
@@ -1,7 +1,14 @@
+require IEx
 defmodule Aprb.Api.SlackTest do
   use ExUnit.Case, async: true
   use Maru.Test, for: Aprb.Api.Slack
-
+  alias Aprb.{Repo, Subscriber, Topic, Subscription}
+  setup_all do
+    Repo.insert(Topic.changeset(%Topic{}, %{name: "subscriptions"}))
+    Repo.insert(Topic.changeset(%Topic{}, %{name: "users"}))
+    Repo.insert(Topic.changeset(%Topic{}, %{name: "inquiries"}))
+    :ok
+  end
   setup do
     System.put_env("SLACK_SLASH_COMMAND_TOKEN", "token")
 
@@ -42,5 +49,35 @@ defmodule Aprb.Api.SlackTest do
       |> put_plug(Plug.Parsers, opts)
       |> post("/slack")
     end
+  end
+
+  test "creates subscriber when receiving proper token" do
+    opts = [
+      parsers: [Plug.Parsers.JSON],
+      pass: ["*/*"],
+      json_decoder: Poison
+    ]
+    conn = build_conn()
+      |> Plug.Conn.put_req_header("content-type", "application/json")
+      |> put_body_or_params(~s({
+          "token":"token",
+          "team_id":"T123456",
+          "team_domain":"example",
+          "channel_id":"C123456",
+          "channel_name":"aprb",
+          "user_id":"U123456",
+          "user_name":"apr",
+          "command":"apr",
+          "text":"subscribe subscriptions users",
+          "response_url":"https://slack.example.com"
+        }))
+      |> put_plug(Plug.Parsers, opts)
+      |> post("/slack")
+    assert Repo.one(Subscriber).channel_id == "C123456"
+    subscriber = Repo.get_by(Subscriber, channel_id: "C123456")
+    subscriber = Repo.preload(subscriber, :topics)
+    IEx.pry
+    assert(Enum.count(subscriber.topics)) == 1
+    assert(List.first(subscriber.topics).name) == "subscriptions"
   end
 end


### PR DESCRIPTION

- Add logic to subscribe/unsubscribe. 
- Added test for subscribe. 
- Add logic for sending events to slack based on channel subscriptions.
- Switched to check subscriptions based on channel and not user

# Todo:
- Add more test (unsubscribe, list, etc)
- Fix issue with test DB, test db doesn't cleanup after each test, so we end up with many topics.
- Add unique constraint on `name` to `Topics` 