### PR TITLE
Adding purchase events

### DIFF
--- a/lib/aprb.ex
+++ b/lib/aprb.ex
@@ -10,7 +10,8 @@ defmodule Aprb do
       supervisor(Aprb.Repo, []),
       worker(Task, [Aprb.EventReceiver, :start_link, ["users"]], id: :users),
       worker(Task, [Aprb.EventReceiver, :start_link, ["subscriptions"]], id: :subscriptions),
-      worker(Task, [Aprb.EventReceiver, :start_link, ["inquiries"]], id: :inquiries)
+      worker(Task, [Aprb.EventReceiver, :start_link, ["inquiries"]], id: :inquiries),
+      worker(Task, [Aprb.EventReceiver, :start_link, ["purchases"]], id: :purchases)
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/lib/services/event_service.ex
+++ b/lib/services/event_service.ex
@@ -39,6 +39,10 @@ defmodule Aprb.Service.EventService do
       "inquiries" ->
         %{text: ":shaka: #{cleanup_name(event["subject"]["display"])} #{event["verb"]} on https://www.artsy.net/artwork/#{event["properties"]["inquireable"]["id"]}",
           unfurl_links: true }
+
+      "purchases" ->
+        %{text: ":shake: #{cleanup_name(event["subject"]["display"])} #{event["verb"]} https://www.artsy.net/artwork/#{event["properties"]["artwork"]["id"]}",
+          unfurl_links: true }
     end
   end
 

--- a/lib/services/slack_command_service.ex
+++ b/lib/services/slack_command_service.ex
@@ -55,6 +55,7 @@ defmodule Aprb.Service.SlackCommandService do
           end
         end
         ":+1: Subscribed to #{Enum.join(subscribed_topics, " ")}"
+
       true ->
         "Unknown command! Supported commands: topics, subscriptions, subscribe <list of topics>, unsubscribe <list of topics>"
     end

--- a/priv/repo/migrations/20160818190952_add_purchases_topic.exs
+++ b/priv/repo/migrations/20160818190952_add_purchases_topic.exs
@@ -1,0 +1,9 @@
+defmodule Aprb.Repo.Migrations.AddPurchasesTopic do
+  use Ecto.Migration
+
+  alias Aprb.{Repo,Topic}
+  def change do
+    changeset = Topic.changeset(%Topic{}, %{name: "purchases"})
+    Repo.insert!(changeset)
+  end
+end


### PR DESCRIPTION
# Adding purchases
- Added Kafka Event receiver for `purchases` topic
- Modified `EventService` to process `purchases` events.