### PR TITLE
Show proper message for unsubscribe

### DIFF
--- a/lib/services/slack_command_service.ex
+++ b/lib/services/slack_command_service.ex
@@ -46,7 +46,7 @@ defmodule Aprb.Service.SlackCommandService do
         if Enum.count(removed_topics) > 0 do
           ":+1: Unsubscribed from #{Enum.join(Enum.map(removed_topics, fn(x) -> "_#{x}_" end), " ")}"
         else
-          "Can't unsubscribe! You were not subscribed to _#{Enum.join(topic_names, " ")}_ or topic doesn't exist."
+          "Can't find a matching subscription to unsubscribe!"
         end
 
       Regex.match?( ~r/subscribe/ , params[:text])  ->

--- a/lib/services/slack_command_service.ex
+++ b/lib/services/slack_command_service.ex
@@ -41,7 +41,13 @@ defmodule Aprb.Service.SlackCommandService do
             end
           end            
         end
-        ":+1: Unsubscribed from #{Enum.join(removed_topics, " ")}"
+        # remove nil from list
+        removed_topics = Enum.reject(removed_topics, fn(x) -> x == nil end)
+        if Enum.count(removed_topics) > 0 do
+          ":+1: Unsubscribed from #{Enum.join(Enum.map(removed_topics, fn(x) -> "_#{x}_" end), " ")}"
+        else
+          "Can't unsubscribe! You were not subscribed to _#{Enum.join(topic_names, " ")}_ or topic doesn't exist."
+        end
 
       Regex.match?( ~r/subscribe/ , params[:text])  ->
         [command | topic_names] = String.split(params[:text], ~r{\s}, parts: 2)

--- a/test/api/slack_test.exs
+++ b/test/api/slack_test.exs
@@ -19,6 +19,25 @@ defmodule Aprb.Api.SlackTest do
     :ok
   end
 
+  def receive_slack_message(token, opts, text, channel_id) do
+    build_conn()
+      |> Plug.Conn.put_req_header("content-type", "application/json")
+      |> put_body_or_params(~s({
+          "token": "#{token}",
+          "team_id":"T123456",
+          "team_domain":"example",
+          "channel_id":"#{channel_id}",
+          "channel_name":"aprb",
+          "user_id":"U123456",
+          "user_name":"apr",
+          "command":"apr",
+          "text": "#{text}",
+          "response_url":"https://slack.example.com"
+        }))
+      |> put_plug(Plug.Parsers, opts)
+      |> post("/slack")
+  end
+
   test "requires a token" do
     assert_raise Maru.Exceptions.InvalidFormatter, "Parsing Param Error: token", fn ->
       post("/slack")
@@ -33,122 +52,65 @@ defmodule Aprb.Api.SlackTest do
     ]
 
     # TODO: check status code
-
-    assert_raise RuntimeError, "Unauthorized", fn -> build_conn()
-      |> Plug.Conn.put_req_header("content-type", "application/json")
-      |> put_body_or_params(~s({
-          "token":"invalid",
-          "team_id":"T123456",
-          "team_domain":"example",
-          "channel_id":"C123456",
-          "channel_name":"aprb",
-          "user_id":"U123456",
-          "user_name":"apr",
-          "command":"apr",
-          "text":"inquiries",
-          "response_url":"https://slack.example.com"
-        }))
-      |> put_plug(Plug.Parsers, opts)
-      |> post("/slack")
+    assert_raise RuntimeError, "Unauthorized", fn ->
+      receive_slack_message("invalid", opts, "inquiries", "C123456")
     end
   end
 
-  test "subscribes to a topic when receiving subscribe command with proper token" do
-    opts = [
-      parsers: [Plug.Parsers.JSON],
-      pass: ["*/*"],
-      json_decoder: Poison
-    ]
-    topic1 = insert(:topic)
-    conn = build_conn()
-      |> Plug.Conn.put_req_header("content-type", "application/json")
-      |> put_body_or_params(~s({
-          "token":"token",
-          "team_id":"T123456",
-          "team_domain":"example",
-          "channel_id":"C123456",
-          "channel_name":"aprb",
-          "user_id":"U123456",
-          "user_name":"apr",
-          "command":"apr",
-          "text":"subscribe #{topic1.name} users",
-          "response_url":"https://slack.example.com"
-        }))
-      |> put_plug(Plug.Parsers, opts)
-      |> post("/slack")
-    assert conn.status == 200
-    assert conn.resp_body == "{\"text\":\":+1: Subscribed to #{topic1.name} \",\"response_type\":\"in_channel\"}"
-    assert Repo.one(Subscriber).channel_id == "C123456"
-    subscriber = Repo.get_by(Subscriber, channel_id: "C123456")
-    subscriber = Repo.preload(subscriber, :topics)
-    assert(Enum.count(subscriber.topics)) == 1
-    assert(List.first(subscriber.topics).name) == "subscriptions"
+  describe "subscribe" do
+    test "subscribes to a topic when receiving subscribe command with proper token" do
+      opts = [
+        parsers: [Plug.Parsers.JSON],
+        pass: ["*/*"],
+        json_decoder: Poison
+      ]
+      topic1 = insert(:topic)
+      conn = receive_slack_message("token", opts, "subscribe #{topic1.name} users", "C123456")
+      assert conn.status == 200
+      assert conn.resp_body == "{\"text\":\":+1: Subscribed to #{topic1.name} \",\"response_type\":\"in_channel\"}"
+      assert Repo.one(Subscriber).channel_id == "C123456"
+      subscriber = Repo.get_by(Subscriber, channel_id: "C123456")
+      subscriber = Repo.preload(subscriber, :topics)
+      assert(Enum.count(subscriber.topics)) == 1
+      assert(List.first(subscriber.topics).name) == "subscriptions"
+    end
   end
 
+  describe "unsubscribe" do
+    test "unsubscribes from a topic when receiving unsubscribe command with proper token" do
+      opts = [
+        parsers: [Plug.Parsers.JSON],
+        pass: ["*/*"],
+        json_decoder: Poison
+      ]
+      topic1 = insert(:topic)
+      subscriber = insert(:subscriber)
+      subscription = insert(:subscription, subscriber: subscriber, topic: topic1)
+      conn = receive_slack_message("token", opts, "unsubscribe #{topic1.name} users", subscriber.channel_id)
 
-  test "unsubscribes from a topic when receiving unsubscribe command with proper token" do
-    opts = [
-      parsers: [Plug.Parsers.JSON],
-      pass: ["*/*"],
-      json_decoder: Poison
-    ]
-    topic1 = insert(:topic)
-    subscriber = insert(:subscriber)
-    subscription = insert(:subscription, subscriber: subscriber, topic: topic1)
-    conn = build_conn()
-      |> Plug.Conn.put_req_header("content-type", "application/json")
-      |> put_body_or_params(~s({
-          "token":"token",
-          "team_id":"T123456",
-          "team_domain":"example",
-          "channel_id":"#{subscriber.channel_id}",
-          "channel_name":"aprb",
-          "user_id":"U123456",
-          "user_name":"apr",
-          "command":"apr",
-          "text":"unsubscribe #{topic1.name} users",
-          "response_url":"https://slack.example.com"
-        }))
-      |> put_plug(Plug.Parsers, opts)
-      |> post("/slack")
+      assert conn.status == 200
+      assert conn.resp_body == "{\"text\":\":+1: Unsubscribed from _#{topic1.name}_\",\"response_type\":\"in_channel\"}"
+      subscriber = Repo.get_by(Subscriber, channel_id: subscriber.channel_id)
+      subscriber = Repo.preload(subscriber, :topics)
+      assert(Enum.count(subscriber.topics)) == 0
+    end
 
-    assert conn.status == 200
-    assert conn.resp_body == "{\"text\":\":+1: Unsubscribed from _#{topic1.name}_\",\"response_type\":\"in_channel\"}"
-    subscriber = Repo.get_by(Subscriber, channel_id: subscriber.channel_id)
-    subscriber = Repo.preload(subscriber, :topics)
-    assert(Enum.count(subscriber.topics)) == 0
-  end
+    test "returns proper message when receiving unsubscribe command for non-subscribed topic" do
+      opts = [
+        parsers: [Plug.Parsers.JSON],
+        pass: ["*/*"],
+        json_decoder: Poison
+      ]
+      topic1 = insert(:topic)
+      subscriber = insert(:subscriber)
+      subscription = insert(:subscription, subscriber: subscriber, topic: topic1)
+      conn = receive_slack_message("token", opts, "unsubscribe random", subscriber.channel_id)
 
-  test "returns proper message when receiving unsubscribe command for non-subscribed topic" do
-    opts = [
-      parsers: [Plug.Parsers.JSON],
-      pass: ["*/*"],
-      json_decoder: Poison
-    ]
-    topic1 = insert(:topic)
-    subscriber = insert(:subscriber)
-    subscription = insert(:subscription, subscriber: subscriber, topic: topic1)
-    conn = build_conn()
-      |> Plug.Conn.put_req_header("content-type", "application/json")
-      |> put_body_or_params(~s({
-          "token":"token",
-          "team_id":"T123456",
-          "team_domain":"example",
-          "channel_id":"#{subscriber.channel_id}",
-          "channel_name":"aprb",
-          "user_id":"U123456",
-          "user_name":"apr",
-          "command":"apr",
-          "text":"unsubscribe random",
-          "response_url":"https://slack.example.com"
-        }))
-      |> put_plug(Plug.Parsers, opts)
-      |> post("/slack")
-
-    assert conn.status == 200
-    assert conn.resp_body == "{\"text\":\"Can't unsubscribe! You were not subscribed to _random_ or topic doesn't exist.\",\"response_type\":\"in_channel\"}"
-    subscriber = Repo.get_by(Subscriber, channel_id: subscriber.channel_id)
-    subscriber = Repo.preload(subscriber, :topics)
-    assert(Enum.count(subscriber.topics)) == 0
+      assert conn.status == 200
+      assert conn.resp_body == "{\"text\":\"Can't find a matching subscription to unsubscribe!\",\"response_type\":\"in_channel\"}"
+      subscriber = Repo.get_by(Subscriber, channel_id: subscriber.channel_id)
+      subscriber = Repo.preload(subscriber, :topics)
+      assert(Enum.count(subscriber.topics)) == 0
+    end
   end
 end


### PR DESCRIPTION
# Problem
When user tries to unsubscribe from topics that they haven't subscribed to or don't exist, we were still showing successful unsubscribe message but the list of unsubscribed topics were empty.

Fixes #32

# Solution
Now if unsubscribe logic didn't unsubscribe from any topic, we will show a message saying:
> Can't unsubscribe! You were not subscribed to _name of topic_ or topic doesn't exist.