### PR TITLE
Add sale artwork link to slack message

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,5 +2,8 @@ use Mix.Config
 
 config :slack, api_token: System.get_env("SLACK_API_TOKEN")
 config :aprb, ecto_repos: [Aprb.Repo]
+config :aprb,
+  gravity_api_url: System.get_env("GRAVITY_API_URL"),
+  gravity_api_token: System.get_env("GRAVITY_API_TOKEN")
 
 import_config "#{Mix.env}.exs"

--- a/lib/clients/gravity.ex
+++ b/lib/clients/gravity.ex
@@ -1,0 +1,10 @@
+defmodule Gravity do
+  use HTTPoison.Base
+
+  def process_url(url) do
+    Application.get_env(:aprb, :gravity_api_url) <> url
+  end
+
+  def process_request_headers(headers), do: Enum.into(%{"X-XAPP-TOKEN" => Application.get_env(:aprb, :gravity_api_token)}, [])
+  def process_response_body(body), do: Poison.decode!(body)
+end

--- a/lib/services/event_service.ex
+++ b/lib/services/event_service.ex
@@ -53,12 +53,17 @@ defmodule Aprb.Service.EventService do
           unfurl_links: true }
       "bidding" ->
         %{
-          text: ":gavel: #{event["type"]} on #{event["lotId"]} from Paddle #{event["bidder"]["paddleNumber"]} ",
+          text: ":gavel: #{event["type"]} on #{fetch_sale_artwork(event["lotId"])}",
           attachments: "[{
                           \"fields\": [
                             {
                               \"title\": \"Amount\",
                               \"value\": \"#{format_price((event["amountCents"] || 0) / 100)}\",
+                              \"short\": true
+                            },
+                            {
+                              \"title\": \"Paddle number\",
+                              \"value\": \"#{event["bidder"]["paddleNumber"]}\",
                               \"short\": true
                             }
                           ]
@@ -66,6 +71,11 @@ defmodule Aprb.Service.EventService do
           unfurl_links: true
          }
     end
+  end
+
+  defp fetch_sale_artwork(lot_id) do
+    sale_artwork_response = Gravity.get!("/sale_artworks/#{lot_id}").body
+    sale_artwork_response["_links"]["permalink"]["href"]
   end
 
   defp get_topic_subscribers(topic_name) do


### PR DESCRIPTION
# Request
Current bidding slack notifications include `lotId` which is not useful, we want to switch to artsy's sale artwork link which will be unfuled and has artwork/artist data.

# Solution
Add a Gravity client which is basically a HTTPPoison wrapper, we use this to call sale artwork endpoint in gravity using event's `lotId` and get sale artworks `permalink`. With that we add permalink to slack message.

<img width="987" alt="screen shot 2016-09-15 at 2 41 16 pm" src="https://cloud.githubusercontent.com/assets/1230819/18562621/82a27668-7b52-11e6-92af-c4b4c274baa1.png">

# Migration
We need to add two new env variables to APRb stack setting:
`GRAVITY_API_URL` and `GRAVITY_API_TOKEN`.

# Follow up
We need to add tests for this and also switch to a proper HAL based Gravity Client.
