### PR TITLE
Support event rollup

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,7 +1,7 @@
 use Mix.Config
 
 config :kafka_ex,
-  brokers: [{"ip-10-0-0-49.ec2.internal", 9092}, {"ip-10-0-0-248.ec2.internal", 9092}],
+  brokers: [{"ip-10-0-0-166.ec2.internal", 9092}],
   consumer_group: System.get_env("KAFKA_CONSUMER_GROUP") || "kafka_ex_2_local",
   disable_default_worker: false,
   sync_timeout: 1000 #Timeout used synchronous requests from kafka. Defaults to 1000ms.

--- a/lib/models/summary.ex
+++ b/lib/models/summary.ex
@@ -20,6 +20,7 @@ defmodule Aprb.Summary do
     model
     |> cast(params, @required_fields, @optional_fields)
     |> foreign_key_constraint(:topic_id)
+    |> unique_constraint(:topic_verb_date, name: :summaries_topic_verb_date_unique_index)
   end
 
   def find_by_topic_verb_date(topic_id, verb, date) do

--- a/lib/models/summary.ex
+++ b/lib/models/summary.ex
@@ -1,0 +1,29 @@
+defmodule Aprb.Summary do
+  use Ecto.Schema
+  import Ecto.Query
+  import Ecto.Changeset
+
+  alias Aprb.{Summary}
+
+  schema "summaries" do
+    field :verb, :string
+    field :summary_date, Ecto.Date
+    field :total_count, :integer
+    belongs_to :topic, Aprb.Topic
+    timestamps
+  end
+
+  @required_fields ~w(topic_id verb summary_date)
+  @optional_fields ~w(total_count)
+
+  def changeset(model, params \\ :empty) do
+    model
+    |> cast(params, @required_fields, @optional_fields)
+    |> foreign_key_constraint(:topic_id)
+  end
+
+  def find_by_topic_verb_date(topic_id, verb, date) do
+    from s in Summary,
+    where: s.topic_id == ^topic_id and s.verb == ^verb and s.summary_date == ^date
+  end
+end

--- a/lib/services/event_service.ex
+++ b/lib/services/event_service.ex
@@ -2,10 +2,11 @@ defmodule Aprb.Service.EventService do
   alias Aprb.{Repo, Topic, Service.SummaryService}
 
   def receive_event(event, topic) do
-    proccessed_message = process_event(decode_event(event), topic)
+    processed_message = decode_event(event)
+                         |> process_event(topic)
     # broadcast a message to a topic
     for subscriber <- get_topic_subscribers(topic) do
-      Slack.Web.Chat.post_message("##{subscriber.channel_name}", proccessed_message[:text], %{attachments: proccessed_message[:attachments], unfurl_links: proccessed_message[:unfurl_links], as_user: true})
+      Slack.Web.Chat.post_message("##{subscriber.channel_name}", processed_message[:text], %{attachments: processed_message[:attachments], unfurl_links: processed_message[:unfurl_links], as_user: true})
     end
   end
 

--- a/lib/services/slack_command_service.ex
+++ b/lib/services/slack_command_service.ex
@@ -65,8 +65,6 @@ defmodule Aprb.Service.SlackCommandService do
       Regex.match?( ~r/summary/, params[:text]) ->
         command_parts = String.split(params[:text], ~r{\s}) |> Enum.drop(1)
         if Enum.count(command_parts) > 0 do
-          require IEx
-          IEx.pry
           topic = Repo.get_by(Topic, name: Enum.at(command_parts, 0))
           date = if Enum.count(command_parts) > 1, do: Calendar.Date.Parse.iso8601(Enum.at(command_parts, 1)), else: Calendar.Date.today! "America/New_York"
           summaries = Repo.all(from s in Summary,

--- a/lib/services/slack_command_service.ex
+++ b/lib/services/slack_command_service.ex
@@ -69,9 +69,10 @@ defmodule Aprb.Service.SlackCommandService do
           date = if Enum.count(command_parts) > 1, do: Calendar.Date.Parse.iso8601(Enum.at(command_parts, 1)), else: Calendar.Date.today! "America/New_York"
           summaries = Repo.all(from s in Summary,
                                where: s.summary_date == ^date and s.topic_id == ^topic.id)
-          summaries
-            |> Enum.map(fn(s) -> "#{s.verb}: #{s.total_count}" end)
-            |> Enum.join(" \r\n ")
+          summaries_text = summaries
+                            |> Enum.map(fn(s) -> "#{s.verb}: #{s.total_count}" end)
+                            |> Enum.join(" \r\n ")
+          ":chart_with_upwards_trend: Summaries for #{date}: \r\n #{summaries_text}"
         end
 
       true ->

--- a/lib/services/summary_service.ex
+++ b/lib/services/summary_service.ex
@@ -1,0 +1,25 @@
+defmodule Aprb.Service.SummaryService do
+  alias Aprb.{Repo, Topic, Summary}
+
+  def update_summary(topic, event) do
+    current_date = Calendar.Date.today! "America/New_York"
+    cond do
+      Enum.member?(~w(subscriptions users inquiries purchases), topic) ->
+        handle_summary(topic, event["verb"], current_date)
+      topic == "bidding" ->
+        handle_summary(topic, event["type"], current_date)
+    end
+  end
+
+  defp handle_summary(topic_name, verb, date) do
+    t = Repo.get_by!(Topic, name: topic_name)
+    summary_query = Summary.find_by_topic_verb_date(t.id, verb, date)
+    if !Repo.one(summary_query) do
+      changeset = Summary.changeset(%Summary{}, %{topic_id: t.id, verb: verb, summary_date: date, total_count: 0})
+      Repo.insert!(changeset)
+    end
+    summary = Repo.one(summary_query)
+    updated_summary = Summary.changeset(summary, %{total_count: summary.total_count + 1})
+    Repo.update(updated_summary)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Aprb.Mixfile do
 
   def application do
     [ mod: {Aprb, []},
-      applications: [:logger, :maru, :kafka_ex, :slack, :postgrex, :ecto]]
+      applications: [:logger, :maru, :kafka_ex, :slack, :postgrex, :ecto, :calendar]]
   end
 
   defp aliases do
@@ -30,6 +30,7 @@ defmodule Aprb.Mixfile do
       {:postgrex, ">= 0.0.0"},
       {:ecto, "~> 2.0.0"},
       {:money, "~> 1.1.0"},
+      {:calendar, "~> 0.16.1"},
       {:ex_machina, "~> 1.0", only: :test} ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
+%{"calendar": {:hex, :calendar, "0.16.1", "782327ad8bae7c797b887840dc4ddb933f05ce6e333e5b04964d7a5d5f79bde3", [:mix], [{:tzdata, "~> 0.5.8 or ~> 0.1.201603", [hex: :tzdata, optional: false]}]},
+  "certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:rebar, :make], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
@@ -24,4 +25,5 @@
   "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []},
   "slack": {:hex, :slack, "0.7.0", "f25c7b9153eafa9bc2d7175982871848388858501a9e2e696e5477b8a6b930f2", [:mix], [{:exjsx, "~> 3.2.0", [hex: :exjsx, optional: false]}, {:httpoison, "~> 0.8.0", [hex: :httpoison, optional: false]}]},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
+  "tzdata": {:hex, :tzdata, "0.5.9", "575be217b039057a47e133b72838cbe104fb5329b19906ea4e66857001c37edb", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, optional: false]}]},
   "websocket_client": {:git, "https://github.com/jeremyong/websocket_client.git", "f6892c8b55004008ce2d52be7d98b156f3e34569", []}}

--- a/priv/repo/migrations/20160919005829_add_summaries_table.exs
+++ b/priv/repo/migrations/20160919005829_add_summaries_table.exs
@@ -1,0 +1,13 @@
+defmodule Aprb.Repo.Migrations.AddSummariesTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:summaries) do
+      add :verb, :string
+      add :summary_date, :date
+      add :total_count, :integer, default: 0
+      add :topic_id, :integer
+      timestamps
+    end
+  end
+end

--- a/priv/repo/migrations/20160919005829_add_summaries_table.exs
+++ b/priv/repo/migrations/20160919005829_add_summaries_table.exs
@@ -9,5 +9,7 @@ defmodule Aprb.Repo.Migrations.AddSummariesTable do
       add :topic_id, :integer
       timestamps
     end
+
+    create unique_index(:summaries, [:topic_id, :verb, :summary_date],  name: :summaries_topic_verb_date_unique_index)
   end
 end

--- a/test/api/slack_test.exs
+++ b/test/api/slack_test.exs
@@ -2,7 +2,7 @@ defmodule Aprb.Api.SlackTest do
   use ExUnit.Case, async: true
   use Maru.Test, for: Aprb.Api.Slack
   import Aprb.Factory
-  alias Aprb.{Repo, Subscriber, Topic, Subscription}
+  alias Aprb.{Repo, Subscriber}
 
   setup_all do
     System.put_env("SLACK_SLASH_COMMAND_TOKEN", "token")
@@ -72,7 +72,7 @@ defmodule Aprb.Api.SlackTest do
       subscriber = Repo.get_by(Subscriber, channel_id: "C123456")
       subscriber = Repo.preload(subscriber, :topics)
       assert(Enum.count(subscriber.topics)) == 1
-      assert(List.first(subscriber.topics).name) == "subscriptions"
+      assert List.first(subscriber.topics).name == topic1.name
     end
   end
 
@@ -85,14 +85,14 @@ defmodule Aprb.Api.SlackTest do
       ]
       topic1 = insert(:topic)
       subscriber = insert(:subscriber)
-      subscription = insert(:subscription, subscriber: subscriber, topic: topic1)
+      insert(:subscription, subscriber: subscriber, topic: topic1)
       conn = receive_slack_message("token", opts, "unsubscribe #{topic1.name} users", subscriber.channel_id)
 
       assert conn.status == 200
       assert conn.resp_body == "{\"text\":\":+1: Unsubscribed from _#{topic1.name}_\",\"response_type\":\"in_channel\"}"
       subscriber = Repo.get_by(Subscriber, channel_id: subscriber.channel_id)
       subscriber = Repo.preload(subscriber, :topics)
-      assert(Enum.count(subscriber.topics)) == 0
+      assert Enum.count(subscriber.topics) == 0
     end
 
     test "returns proper message when receiving unsubscribe command for non-subscribed topic" do
@@ -103,14 +103,14 @@ defmodule Aprb.Api.SlackTest do
       ]
       topic1 = insert(:topic)
       subscriber = insert(:subscriber)
-      subscription = insert(:subscription, subscriber: subscriber, topic: topic1)
+      insert(:subscription, subscriber: subscriber, topic: topic1)
       conn = receive_slack_message("token", opts, "unsubscribe random", subscriber.channel_id)
 
       assert conn.status == 200
       assert conn.resp_body == "{\"text\":\"Can't find a matching subscription to unsubscribe!\",\"response_type\":\"in_channel\"}"
       subscriber = Repo.get_by(Subscriber, channel_id: subscriber.channel_id)
       subscriber = Repo.preload(subscriber, :topics)
-      assert(Enum.count(subscriber.topics)) == 0
+      assert Enum.count(subscriber.topics) == 1
     end
   end
 end

--- a/test/services/event_service_test.exs
+++ b/test/services/event_service_test.exs
@@ -1,0 +1,27 @@
+defmodule Aprb.Service.EventServiceTest do
+  use ExUnit.Case, async: true
+  import Aprb.Factory
+  alias Aprb.{Repo, Summary, Service.EventService}
+  
+  setup do
+    Ecto.Adapters.SQL.Sandbox.mode(Repo, { :shared, self() })
+    Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+    :ok
+  end
+
+  test "process_event: users" do
+    topic = insert(:topic, name: "users")
+    event = %{
+               "subject" => %{"display" => "Best collector"},
+               "verb" => "followed",
+               "properties" => %{
+                  "artist" => %{
+                    "id" => "test-artist"
+                  }
+               }
+             }
+    response = EventService.process_event(event, "users")
+    assert response[:text]  == ":heart: Best followed https://www.artsy.net/artist/test-artist"
+    assert response[:unfurl_links]  == true
+  end
+end

--- a/test/services/slack_command_service_test.exs
+++ b/test/services/slack_command_service_test.exs
@@ -18,6 +18,7 @@ defmodule Aprb.Service.SlackCommandServiceTest do
     params = %{channel_id: "artists", text: "summary artworks"}
     response = SlackCommandService.process_command(params)
     assert response[:response_type] == "in_channel"
-    assert response[:text] == "created: 10 \r\n sold: 5"
+    today = Calendar.Date.today! "America/New_York"
+    assert response[:text] == ":chart_with_upwards_trend: Summaries for #{today}: \r\n created: 10 \r\n sold: 5"
   end
 end

--- a/test/services/slack_command_service_test.exs
+++ b/test/services/slack_command_service_test.exs
@@ -1,0 +1,23 @@
+defmodule Aprb.Service.SlackCommandServiceTest do
+  use ExUnit.Case, async: true
+  import Aprb.Factory
+  alias Aprb.{Repo, Summary, Service.SlackCommandService}
+  
+  setup do
+    Ecto.Adapters.SQL.Sandbox.mode(Repo, { :shared, self() })
+    Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+    :ok
+  end
+
+  test "process_command: summary" do
+    subscriber = insert(:subscriber, channel_id: "artists")
+    topic = insert(:topic, name: "artworks")
+    created_summary = insert(:summary, topic: topic, verb: "created", total_count: 10)
+    sold_summary = insert(:summary, topic: topic, verb: "sold", total_count: 5)
+    another_topic_summary = insert(:summary, topic: insert(:topic), verb: "created", total_count: 20)
+    params = %{channel_id: "artists", text: "summary artworks"}
+    response = SlackCommandService.process_command(params)
+    assert response[:response_type] == "in_channel"
+    assert response[:text] == "created: 10 \r\n sold: 5"
+  end
+end

--- a/test/services/summary_service_test.exs
+++ b/test/services/summary_service_test.exs
@@ -1,0 +1,40 @@
+defmodule Aprb.Service.SummaryServiceTest do
+  use ExUnit.Case, async: true
+  import Aprb.Factory
+  alias Aprb.{Repo, Summary, Service.SummaryService}
+  
+  setup do
+    Ecto.Adapters.SQL.Sandbox.mode(Repo, { :shared, self() })
+    Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+    :ok
+  end
+
+  test "update_summary: users" do
+    topic = insert(:topic, name: "users")
+    event = %{
+               "subject" => %{"display" => "Best collector"},
+               "verb" => "followed",
+               "properties" => %{
+                  "artist" => %{
+                    "id" => "test-artist"
+                  }
+               }
+             }
+    assert Repo.aggregate(Summary, :count, :verb) == 0
+    response = SummaryService.update_summary("users", event)
+    assert Repo.aggregate(Summary, :count, :verb) == 1
+    summary = Repo.one(Summary)
+    assert summary.topic_id == topic.id
+    assert summary.verb == "followed"
+    assert summary.total_count == 1
+
+    # sending event again will add total_count in summary
+    SummaryService.update_summary("users", event)
+    # we don't add a new summary
+    assert Repo.aggregate(Summary, :count, :verb) == 1
+    summary = Repo.one(Summary)
+    assert summary.topic_id == topic.id
+    assert summary.verb == "followed"
+    assert summary.total_count == 2
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -25,4 +25,14 @@ defmodule Aprb.Factory do
       topic: build(:topic)
     }
   end
+
+  def summary_factory do
+    {:ok, date} = Ecto.Date.cast(Calendar.Date.today!("America/New_York"))
+    %Aprb.Summary{
+      topic: build(:topic),
+      verb: "followed",
+      summary_date: date,
+      total_count: 0
+    }
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,6 @@
 ExUnit.start()
+ExUnit.configure seed: elem(:os.timestamp, 2)
 Aprb.Repo.start_link()
 Ecto.Adapters.SQL.Sandbox.mode(Aprb.Repo, :auto)
 Application.ensure_all_started(:ex_machina)
+Application.ensure_all_started(:calendar)


### PR DESCRIPTION
# Feature
We want to be able to store count of (topic, verbs) for each day. So instead of showing all artist follows we could ask for total number of follows for specific day.

Fixes #30 

# Solution
Added new `Summary` model which holds `topic_id`, `verb`, `total_count` and `summary_date`. Basically every time we get a new event we call new `SummaryService.update_summary` which basically parses the event and creates/updates a row in `summaries` table.

Also added a new slack command:
```
/aprb summary <topic> <optional date in YYYY-MM-DD format>
```
which will return total counts for each `verb` in that topic.

# Notes
- Added new test files for `SlackService`, `EventService` and newly added `SummaryService`. We still need to add more test cases but this should be a good start.
- Switched to staging Kafka for dev.