### PR TITLE
Buyer outcome events

### DIFF
--- a/lib/aprb.ex
+++ b/lib/aprb.ex
@@ -12,7 +12,8 @@ defmodule Aprb do
       worker(Task, [Aprb.EventReceiver, :start_link, ["subscriptions"]], id: :subscriptions),
       worker(Task, [Aprb.EventReceiver, :start_link, ["inquiries"]], id: :inquiries),
       worker(Task, [Aprb.EventReceiver, :start_link, ["purchases"]], id: :purchases),
-      worker(Task, [Aprb.EventReceiver, :start_link, ["bidding"]], id: :bidding)
+      worker(Task, [Aprb.EventReceiver, :start_link, ["bidding"]], id: :bidding),
+      worker(Task, [Aprb.EventReceiver, :start_link, ["conversations"]], id: :conversations)
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/lib/services/event_service.ex
+++ b/lib/services/event_service.ex
@@ -82,6 +82,27 @@ defmodule Aprb.Service.EventService do
                         }]",
           unfurl_links: true
          }
+      "conversations" ->
+        if event["properties"]["buyer_outcome"] == "other" do
+          %{
+            text: ":phone: #{event["object"]["display"]} responded on https://radiation.artsy.net/accounts/2/conversations/#{event["properties"]["radiation_conversation_id"]}",
+            attachments: "[{
+                            \"fields\": [
+                              {
+                                \"title\": \"Outcome\",
+                                \"value\": \"#{event["properties"]["buyer_outcome"]}\",
+                                \"short\": true
+                              },
+                              {
+                                \"title\": \"Comment\",
+                                \"value\": \"#{event["properties"]["buyer_outcome_comment"]}\",
+                                \"short\": false
+                              }
+                            ]
+                          }]",
+            unfurl_links: false
+          }
+        end
     end
   end
 

--- a/lib/services/summary_service.ex
+++ b/lib/services/summary_service.ex
@@ -4,7 +4,7 @@ defmodule Aprb.Service.SummaryService do
   def update_summary(topic, event) do
     current_date = Calendar.Date.today! "America/New_York"
     cond do
-      Enum.member?(~w(subscriptions users inquiries purchases), topic) ->
+      Enum.member?(~w(subscriptions users inquiries purchases conversations), topic) ->
         handle_summary(topic, event["verb"], current_date)
       topic == "bidding" ->
         handle_summary(topic, event["type"], current_date)

--- a/priv/repo/migrations/20160928174439_add_conversations_topic.exs
+++ b/priv/repo/migrations/20160928174439_add_conversations_topic.exs
@@ -1,0 +1,9 @@
+defmodule Aprb.Repo.Migrations.AddConversationsTopic do
+  use Ecto.Migration
+
+  alias Aprb.{Repo,Topic}
+  def change do
+    changeset = Topic.changeset(%Topic{}, %{name: "conversations"})
+    Repo.insert!(changeset)
+  end
+end

--- a/test/services/event_service_test.exs
+++ b/test/services/event_service_test.exs
@@ -24,4 +24,39 @@ defmodule Aprb.Service.EventServiceTest do
     assert response[:text]  == ":heart: Best followed https://www.artsy.net/artist/test-artist"
     assert response[:unfurl_links]  == true
   end
+
+  test "process_event: conversations" do
+    topic = insert(:topic, name: "conversations")
+    event = %{
+               "object" => %{"display" => "Collector 1"},
+               "subject" => %{"display" => "Gallery 1"},
+               "verb" => "received",
+               "properties" => %{
+                  "radiation_conversation_id" => "123",
+                  "buyer_outcome" => "other",
+                  "buyer_outcome_comment" => "never received response",
+                  "inquiry_id" => "inq1"
+               }
+             }
+    response = EventService.process_event(event, "conversations")
+    assert response[:text]  == ":phone: Collector 1 responded on https://radiation.artsy.net/accounts/2/conversations/123"
+    assert response[:unfurl_links]  == false
+  end
+
+  test "process_event: conversations ignores non-other outcomes" do
+    topic = insert(:topic, name: "conversations")
+    event = %{
+               "object" => %{"display" => "Collector 1"},
+               "subject" => %{"display" => "Gallery 1"},
+               "verb" => "received",
+               "properties" => %{
+                  "radiation_conversation_id" => "123",
+                  "buyer_outcome" => "purchased",
+                  "buyer_outcome_comment" => nil,
+                  "inquiry_id" => "inq1"
+               }
+             }
+    response = EventService.process_event(event, "conversations")
+    assert response == nil
+  end
 end


### PR DESCRIPTION
# Request
Get slack notifications everytime a collector responded `other` with a comment to our Quick Follow up emails.

# Solution
https://github.com/artsy/impulse/pull/120 adds new `conversations` topic and will post events to this topic everytime we get a new buyer outcome. Here we are listening on new `conversations` topic and send proper message to slack about it.

<img width="946" alt="screen shot 2016-09-28 at 2 11 59 pm" src="https://cloud.githubusercontent.com/assets/1230819/18926855/6a738ad4-8587-11e6-9e59-a4b8072bb536.png">


# Selfie
![selfie-0](http://i.imgur.com/Yg2Rpif.png)

[_GitHub Selfies_](https://github.com/thieman/github-selfies/)
