### PR TITLE
Update circleci docker

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
 machine:
+  pre:
+    - curl -sSL https://s3.amazonaws.com/circle-downloads/install-circleci-docker.sh | bash -s -- 1.10.0
   services:
     - docker
 


### PR DESCRIPTION
We need to upgrade to docker 1.10 to be able to generate multiple tags for same image. Following https://discuss.circleci.com/t/docker-1-10-0-is-available-beta/2100