### PR TITLE
Move builindg docker images to deploy process

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,8 +12,6 @@ dependencies:
     - ~/.mix
     - _build
     - deps
-  override:
-    - docker build -t $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/aprb:$CIRCLE_SHA1 -t $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/aprb:latest .
 
 test:
   override:
@@ -23,4 +21,5 @@ deployment:
   prod:
     branch: master
     commands:
+      - docker build -t $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/aprb:$CIRCLE_SHA1 -t $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/aprb:latest .
       - ./scripts/deploy.sh


### PR DESCRIPTION
# Problem
Circleci builds are [failing](https://circleci.com/gh/artsy/aprb/13) on PRs (#49) because environment variables are [not available](https://circleci.com/docs/fork-pr-builds/) in PR fork builds and missing `AWS_ACCOUNT_ID` is causing build command to fail.

# Solution
Move building docker image to deploy process which will only happen for master branch builds.