### PR TITLE
Fix nil messages to slack

### DIFF
--- a/lib/services/event_service.ex
+++ b/lib/services/event_service.ex
@@ -5,8 +5,10 @@ defmodule Aprb.Service.EventService do
     processed_message = decode_event(event)
                          |> process_event(topic)
     # broadcast a message to a topic
-    for subscriber <- get_topic_subscribers(topic) do
-      Slack.Web.Chat.post_message("##{subscriber.channel_name}", processed_message[:text], %{attachments: processed_message[:attachments], unfurl_links: processed_message[:unfurl_links], as_user: true})
+    if processed_message != nil do
+      for subscriber <- get_topic_subscribers(topic) do
+        Slack.Web.Chat.post_message("##{subscriber.channel_name}", processed_message[:text], %{attachments: processed_message[:attachments], unfurl_links: processed_message[:unfurl_links], as_user: true})
+      end
     end
   end
 


### PR DESCRIPTION
# Problem
With current logic for `subscriptions` events, it's possible to return`nil` for `processed_message` here https://github.com/artsy/aprb/blob/master/lib/services/event_service.ex#L5 when `verb` is not `buyer_outcome_set` or outcome wasn't `other`.

# Solution
Check for nil `processed_message` and only call slack if it was not nil!

# Followup
Add test to make sure slack is not called for empty processed message.