### PR TITLE
Migrate db in deploy process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ ENV PORT 4000
 ENV MIX_ENV prod
 RUN mix deps.get
 RUN mix compile
-CMD mix run --no-halt
+CMD mix ecto.migrate && mix run --no-halt


### PR DESCRIPTION
# Problem
In new k8s approach for deploying APRB we are missing db migration step.

# Solution
Run `mix ecto.migrate` before starting app in container in Dockerfile