### PR TITLE
Add terraform and RDS instance

### DIFF
--- a/terraform/.terragrunt
+++ b/terraform/.terragrunt
@@ -1,0 +1,15 @@
+lock = {
+  backend = "dynamodb"
+  config {
+    state_file_id = "aprb"
+  }
+}
+
+remote_state = {
+  backend = "s3"
+  config {
+    bucket = "artsy-terraform"
+    key = "aprb/terraform.tfstate"
+    region = "us-east-1"
+  }
+}

--- a/terraform/00-main.tf
+++ b/terraform/00-main.tf
@@ -1,0 +1,10 @@
+provider "aws" {}
+
+data "terraform_remote_state" "infrastructure" {
+    backend = "s3"
+    config {
+        bucket = "artsy-terraform"
+        key = "infrastructure/terraform.tfstate"
+        region = "us-east-1"
+    }
+}

--- a/terraform/01-production.tf
+++ b/terraform/01-production.tf
@@ -1,0 +1,32 @@
+resource "aws_db_instance" "aprb-production" {
+    identifier = "aprb-production"
+    name = "aprb_production"
+
+    engine = "postgres"
+    engine_version = "9.5.2"
+
+    instance_class = "db.t2.micro"
+    storage_type = "gp2"
+
+    allocated_storage = "5"
+    multi_az = false
+
+    auto_minor_version_upgrade = true
+
+    option_group_name = "default:postgres-9-5"
+    parameter_group_name = "default.postgres9.5"
+
+    db_subnet_group_name = "${data.terraform_remote_state.infrastructure.vpc_production_default_db_subnet_group_id}"
+    vpc_security_group_ids = [
+        "${data.terraform_remote_state.infrastructure.vpc_production_default_sg_id}"
+    ]
+    publicly_accessible = true
+
+    username = "aprb_prod"
+    # password = ""
+
+    tags = {
+        "workload-type" = "production"
+    }
+
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,11 @@
+# Terraform
+
+Install and configure Terraform as documented [here](https://github.com/artsy/infrastructure#terraform)
+
+Install Terragrunt as documented [here](https://github.com/gruntwork-io/terragrunt#install)
+
+- Make changes to `*.tf` files describing changes to resources rather than modifying them directly in EC2.
+
+- To stage changes before applying, run `terragrunt plan -out=./changes.tfplan`
+
+- To apply changes, run `terragrunt apply changes.tfplan`


### PR DESCRIPTION
- Adds terragrunt config
- Adds aprb-production via terraform

Achtung!

The existing RDS db is already imported into terraform state so `terragrunt plan` should show no changes.

Do *not* run `terraform apply` before merging this PR, or else it will delete the aprb-production database already created!
