### PR TITLE
Update inquiry request slack message with details

### DIFF
--- a/lib/services/event_service.ex
+++ b/lib/services/event_service.ex
@@ -49,6 +49,20 @@ defmodule Aprb.Service.EventService do
 
       "inquiries" ->
         %{text: ":shaka: #{cleanup_name(event["subject"]["display"])} #{event["verb"]} on https://www.artsy.net/artwork/#{event["properties"]["inquireable"]["id"]}",
+          attachments: "[{
+                          \"fields\": [
+                            {
+                              \"title\": \"Professional Buyer?\",
+                              \"value\": \"#{event["properties"]["inquirer"]["professional_buyer"]}\",
+                              \"short\": true
+                            },
+                            {
+                              \"title\": \"Message Snippet\",
+                              \"value\": \"#{event["properties"]["initial_message_snippet"]}\",
+                              \"short\": false
+                            }
+                          ]
+                        }]",
           unfurl_links: true }
 
       "purchases" ->


### PR DESCRIPTION
Add more details to inquiry request slack messages to include Professional Buyer flag and also initial message snippet.
Follow changes from https://github.com/artsy/gravity/pull/10653/