### PR TITLE
 Fix duplicate id for GenServer issue

### DIFF
--- a/lib/aprb.ex
+++ b/lib/aprb.ex
@@ -14,7 +14,7 @@ defmodule Aprb do
       worker(Task, [Aprb.EventReceiver, :start_link, ["purchases"]], id: :purchases),
       worker(Task, [Aprb.EventReceiver, :start_link, ["bidding"]], id: :bidding),
       worker(Task, [Aprb.EventReceiver, :start_link, ["conversations"]], id: :conversations),
-      worker(Aprb.Service.AmqEventService, ["conversations"], id: :conversations),
+      worker(Aprb.Service.AmqEventService, ["conversations"], id: :amq_conversations),
       worker(Aprb.Service.AmqEventService, ["radiation.messages"], id: :radiation_messages)
     ]
 


### PR DESCRIPTION
# Problem
We started getting these errors after prev deploy:
```
Jan 09 12:14:59 k8s-worker-0.prd.artsy.systems docker/k8s_aprb.8e3e6832_aprb-492304161-l46cb_default_9ba25de3-d:      ** (EXIT) an exception was raised:
Jan 09 12:14:59 k8s-worker-0.prd.artsy.systems docker/k8s_aprb.8e3e6832_aprb-492304161-l46cb_default_9ba25de3-d:          ** (ArgumentError) duplicated id :conversations found in the supervisor specification, please explicitly pass the :id option when defining this worker/supervisor
```

# Solution
Could not use same id for workers even if they are for different GenServer modules. Changing new conversation amq based GenServer id.