### PR TITLE
Use elixir:1.3.0 image instead of the latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir
+FROM elixir:1.3.0
 
 RUN mix local.hex --force
 RUN mix local.rebar --force


### PR DESCRIPTION
Elixir image in Dockerhub has been updated recently which has caused few issues for us. Some weird errors with `merge` and keyword arguments. Switching to `1.3.0` instead of latest.