### PR TITLE
@ashkan18 => divide bidding amounts by 100

### DIFF
--- a/lib/views/bidding_slack_view.ex
+++ b/lib/views/bidding_slack_view.ex
@@ -9,7 +9,7 @@ defmodule Aprb.Views.BiddingSlackView do
                       \"fields\": [
                         {
                           \"title\": \"Amount\",
-                          \"value\": \"#{format_price(event["amountCents"])}\",
+                          \"value\": \"#{format_price(event["amountCents"] / 100)}\",
                           \"short\": true
                         },
                         {


### PR DESCRIPTION
The `amountCents` we receive from Causality is in cents 😄 so we have to divide by 100. (Note that this is another thing that will break when we decide we want to support Yen). 