### PR TITLE
Support rabbitmq bidding events

### DIFF
--- a/lib/aprb.ex
+++ b/lib/aprb.ex
@@ -8,13 +8,14 @@ defmodule Aprb do
 
     children = [
       supervisor(Aprb.Repo, []),
-      worker(Task, [Aprb.EventReceiver, :start_link, ["users"]], id: :users),
-      worker(Task, [Aprb.EventReceiver, :start_link, ["purchases"]], id: :purchases),
-      worker(Task, [Aprb.EventReceiver, :start_link, ["bidding"]], id: :bidding),
-      worker(Aprb.Service.AmqEventService, ["conversations"], id: :amq_conversations),
+      worker(Task, [Aprb.EventReceiver, :start_link, ["users"]], id: :kafka_users),
+      worker(Task, [Aprb.EventReceiver, :start_link, ["purchases"]], id: :kafka_purchases),
+      worker(Task, [Aprb.EventReceiver, :start_link, ["bidding"]], id: :kafka_bidding),
+      worker(Aprb.Service.AmqEventService, ["conversations"], id: :conversations),
       worker(Aprb.Service.AmqEventService, ["inquiries"], id: :amq_inquiries),
       worker(Aprb.Service.AmqEventService, ["radiation.messages"], id: :radiation_messages),
-      worker(Aprb.Service.AmqEventService, ["subscriptions"], id: :subscriptions)
+      worker(Aprb.Service.AmqEventService, ["subscriptions"], id: :subscriptions).
+      worker(Aprb.Service.AmqEventService, ["bidding"], id: :bidding)
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/lib/aprb.ex
+++ b/lib/aprb.ex
@@ -15,7 +15,7 @@ defmodule Aprb do
       worker(Aprb.Service.AmqEventService, ["inquiries"], id: :amq_inquiries),
       worker(Aprb.Service.AmqEventService, ["radiation.messages"], id: :radiation_messages),
       worker(Aprb.Service.AmqEventService, ["subscriptions"], id: :subscriptions).
-      worker(Aprb.Service.AmqEventService, ["bidding"], id: :bidding)
+      worker(Aprb.Service.AmqEventService, ["auctions"], id: :auctions)
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/lib/services/event_service.ex
+++ b/lib/services/event_service.ex
@@ -31,6 +31,8 @@ defmodule Aprb.Service.EventService do
         Aprb.Views.PurchaseSlackView.render(event)
       "bidding" ->
         Aprb.Views.BiddingSlackView.render(event)
+      "auctions" ->
+        Aprb.Views.BiddingSlackView.render(event)
       "radiation.messages" ->
         Aprb.Views.RadiationMessageSlackView.render(event)
       "conversations" ->

--- a/priv/repo/migrations/20170214204816_rename-bidding-to-auctions.exs
+++ b/priv/repo/migrations/20170214204816_rename-bidding-to-auctions.exs
@@ -1,0 +1,9 @@
+defmodule :"Elixir.Aprb.Repo.Migrations.Rename-bidding-to-auctions" do
+  use Ecto.Migration
+  alias Aprb.{Repo,Topic}
+  def change do
+    bidding_topic = Repo.get_by!(Topic, name: "bidding")
+    auction_topic = Topic.changeset(bidding_topic, %{name: "auctions"})
+    Repo.update!(auction_topic)
+  end
+end


### PR DESCRIPTION
# Change
We are moving form Kafka to RabbitMQ for `bidding` events. Also in https://github.com/artsy/causality/pull/348, bidding topic has been renamed to `auctions`, in this PR we stop listening on `bidding` on Kafka and start listening on `auctions` on rabbitmq, currently we don't do anything with routing key since there is only one event (second bidder) is produces but later on we may want to revisit this if we started getting more events.

related to: https://github.com/artsy/causality/pull/348