### PR TITLE
Remove Subscription from normal handling for summary

### DIFF
--- a/lib/services/summary_service.ex
+++ b/lib/services/summary_service.ex
@@ -8,7 +8,7 @@ defmodule Aprb.Service.SummaryService do
     cond do
       Enum.member?(~w(users inquiries purchases conversations radiation.messages), topic.name) ->
         handle_summary(topic, event["verb"], current_date)
-      topic.name == 'subscriptions' ->
+      Enum.member?(~w(subscriptions), topic.name) ->
         handle_summary(topic, SubscriptionHelper.parsed_verb(event), current_date)
       Enum.member?(~w(auctions bidding), topic.name) ->
         handle_summary(topic, event["type"], current_date)

--- a/lib/services/summary_service.ex
+++ b/lib/services/summary_service.ex
@@ -6,7 +6,7 @@ defmodule Aprb.Service.SummaryService do
   def update_summary(topic, event) do
     current_date = Calendar.Date.today! "America/New_York"
     cond do
-      Enum.member?(~w(subscriptions users inquiries purchases conversations radiation.messages), topic.name) ->
+      Enum.member?(~w(users inquiries purchases conversations radiation.messages), topic.name) ->
         handle_summary(topic, event["verb"], current_date)
       topic.name == 'subscriptions' ->
         handle_summary(topic, SubscriptionHelper.parsed_verb(event), current_date)

--- a/test/services/event_service_test.exs
+++ b/test/services/event_service_test.exs
@@ -2,7 +2,7 @@ defmodule Aprb.Service.EventServiceTest do
   use ExUnit.Case, async: false
   import Aprb.Factory
   alias Aprb.{Repo, Service.EventService}
-  
+
   setup do
     Ecto.Adapters.SQL.Sandbox.checkout(Repo)
     Ecto.Adapters.SQL.Sandbox.mode(Aprb.Repo, { :shared, self() })
@@ -35,7 +35,8 @@ defmodule Aprb.Service.EventServiceTest do
                "properties" => %{
                   "partner" => %{
                     "name" => "gallery 1",
-                    "outreach_admin" => "tester admin"
+                    "outreach_admin" => "tester admin",
+                    "initial_subscription" => false
                   }
                }
              }


### PR DESCRIPTION
We added logic to process summary for `subscriptions` differently in https://github.com/artsy/aprb/pull/79, but we still had it in the check for normal summary calculation.

Removed it from there.