### PR TITLE
Add listening on invoices topic and post messages

### DIFF
--- a/lib/aprb.ex
+++ b/lib/aprb.ex
@@ -14,6 +14,7 @@ defmodule Aprb do
       worker(Aprb.Service.AmqEventService, [%{topic: "subscriptions"}], id: :subscriptions),
       worker(Aprb.Service.AmqEventService, [%{topic: "auctions", routing_key: "SecondPriceBidPlaced"}], id: :auctions),
       worker(Aprb.Service.AmqEventService, [%{topic: "purchases"}], id: :purchases),
+      worker(Aprb.Service.AmqEventService, [%{topic: "invoices"}], id: :invoices)
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/lib/services/event_service.ex
+++ b/lib/services/event_service.ex
@@ -28,8 +28,6 @@ defmodule Aprb.Service.EventService do
         Aprb.Views.InquirySlackView.render(event)
       "purchases" ->
         Aprb.Views.PurchaseSlackView.render(event)
-      "bidding" ->
-        Aprb.Views.BiddingSlackView.render(event)
       "auctions" ->
         Aprb.Views.BiddingSlackView.render(event)
       "radiation.messages" ->

--- a/lib/services/event_service.ex
+++ b/lib/services/event_service.ex
@@ -36,6 +36,8 @@ defmodule Aprb.Service.EventService do
         Aprb.Views.RadiationMessageSlackView.render(event)
       "conversations" ->
         Aprb.Views.ConversationSlackView.render(event)
+      "invoices" ->
+        Aprb.Views.InvoiceSlackView.render(event)
     end
   end
 

--- a/lib/services/summary_service.ex
+++ b/lib/services/summary_service.ex
@@ -10,7 +10,7 @@ defmodule Aprb.Service.SummaryService do
         handle_summary(topic, event["verb"], current_date)
       Enum.member?(~w(subscriptions), topic.name) ->
         handle_summary(topic, SubscriptionHelper.parsed_verb(event), current_date)
-      Enum.member?(~w(auctions bidding), topic.name) ->
+      Enum.member?(~w(auctions), topic.name) ->
         handle_summary(topic, event["type"], current_date)
     end
   end

--- a/lib/views/invoice_slack_view.ex
+++ b/lib/views/invoice_slack_view.ex
@@ -1,0 +1,29 @@
+defmodule Aprb.Views.InvoiceSlackView do
+  import Aprb.ViewHelper
+
+  def render(event) do
+    partner_data = fetch_partner_data(event["properties"]["partner_id"])
+    %{
+      text: ":money_with_wings: Invoice #{event["object"]["display"]} #{event["verb"]}",
+      attachments: "[{
+                      \"fields\": [
+                        {
+                          \"title\": \"Total\",
+                          \"value\": \"#{format_price(event["properties"]["total_cents"]) / 100}\",
+                          \"short\": true
+                        },
+                        {
+                          \"title\": \"Partner\",
+                          \"value\": \"#{partner_data["name"]}\",
+                          \"short\": true
+                        }
+                      ]
+                    }]",
+      unfurl_links: true
+    }
+  end
+
+  defp fetch_partner_data(partner_id) do
+    Gravity.get!("/partners/#{partner_id}").body
+  end
+end

--- a/priv/repo/migrations/20170523182402_add-invoices-topic.exs
+++ b/priv/repo/migrations/20170523182402_add-invoices-topic.exs
@@ -1,0 +1,12 @@
+defmodule :"Elixir.Aprb.Repo.Migrations.Add-invoices-topic" do
+  use Ecto.Migration
+
+  alias Aprb.{Repo,Topic}
+
+  def change do
+    changeset = Topic.changeset(%Topic{}, %{name: "invoices"})
+    Repo.insert!(changeset)
+    bidding_topic = Repo.get_by!(Topic, name: "bidding")
+    Repo.delete bidding_topic
+  end
+end

--- a/priv/repo/migrations/20170523182402_add-invoices-topic.exs
+++ b/priv/repo/migrations/20170523182402_add-invoices-topic.exs
@@ -6,7 +6,7 @@ defmodule :"Elixir.Aprb.Repo.Migrations.Add-invoices-topic" do
   def change do
     changeset = Topic.changeset(%Topic{}, %{name: "invoices"})
     Repo.insert!(changeset)
-    bidding_topic = Repo.get_by!(Topic, name: "bidding")
-    Repo.delete bidding_topic
+    bidding_topic = Repo.get_by(Topic, name: "bidding")
+    if bidding_topic != nil, do: Repo.delete_all bidding_topic
   end
 end


### PR DESCRIPTION
# Change
Start listening on new `invoices` topic and post to slack when getting new event.

# Migrations 
Add new `invoices` to `topics`
Remove `bidding` now that we've moved to `auctions`