### PR TITLE
Add artworks titles to slack message

### DIFF
--- a/lib/helpers/view_helper.ex
+++ b/lib/helpers/view_helper.ex
@@ -37,4 +37,10 @@ defmodule Aprb.ViewHelper do
       "N/A"
     end
   end
+
+  def artworks_display_from_artworkgroups(artworkgroups) do
+    artworkgroups
+      |> Enum.map(fn(ag) -> "#{ag[:title]}(#{ag[:artists]})" end)
+      |> Enum.join(', ')
+  end
 end

--- a/lib/views/invoice_slack_view.ex
+++ b/lib/views/invoice_slack_view.ex
@@ -4,9 +4,14 @@ defmodule Aprb.Views.InvoiceSlackView do
   def render(event) do
     partner_data = fetch_partner_data(event["properties"]["partner_id"])
     %{
-      text: ":money_with_wings: Invoice #{event["object"]["display"]} #{event["verb"]}",
+      text: ":money_with_wings: Invoice #{event["object"]["display"]}",
       attachments: "[{
                       \"fields\": [
+                        {
+                          \"title\": \"Artworks\",
+                          \"value\": \"#{artworks_display_from_artworkgroups(event["properties"]["artwork_groups"])}\",
+                          \"short\": false
+                        },
                         {
                           \"title\": \"Total\",
                           \"value\": \"#{format_price(event["properties"]["total_cents"] / 100)}\",


### PR DESCRIPTION
# Current message looks like

![screen shot 2017-05-23 at 8 45 47 pm](https://cloud.githubusercontent.com/assets/1230819/26382221/d5552ef8-3ff8-11e7-9236-9339f75753ba.png)

# How to make it more useful?
Added Artwork title and artists for artwork groups.
