### PR TITLE
Switch to string from character list

### DIFF
--- a/lib/helpers/view_helper.ex
+++ b/lib/helpers/view_helper.ex
@@ -40,7 +40,7 @@ defmodule Aprb.ViewHelper do
 
   def artworks_display_from_artworkgroups(artworkgroups) do
     artworkgroups
-      |> Enum.map(fn(ag) -> "#{ag[:title]}(#{ag[:artists]})" end)
-      |> Enum.join(', ')
+      |> Enum.map(fn(ag) -> "#{ag["title"]}(#{ag["artists"]})" end)
+      |> Enum.join(", ")
   end
 end


### PR DESCRIPTION
# Problem
We used `'` for string after switching gear from Ruby to Elixir, In Elixir `'` is a Character list and is not binary while `"` is binary and String.

http://culttt.com/2016/03/21/working-strings-elixir/

This fixes that