### PR TITLE
ensure zero-downtime rollingupdate

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -5,6 +5,11 @@ metadata:
   name: aprb-web
 spec:
   replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -5,6 +5,11 @@ metadata:
   name: aprb-web
 spec:
   replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
   template:
     metadata:
       labels:


### PR DESCRIPTION
This will ensure new contains come up before the old ones are terminated, when doing a `hokusai deploy` `hokusai refresh` etc

cc @joeyAghion you will want to add this to Diffusion as well