### PR TITLE
Add root endpoint to make DNS happy

### DIFF
--- a/lib/api/root.ex
+++ b/lib/api/root.ex
@@ -10,4 +10,9 @@ defmodule Aprb.Api.Root do
   end
   mount Aprb.Api.Ping
   mount Aprb.Api.Slack
+
+  desc "Root endpoint get"
+  get do
+    text(conn, "Tune into APR!")
+  end
 end


### PR DESCRIPTION
# Problem
DNS stopped serving APRb since there is no @GET on root. This most likely happened after few dependencies updates recently.

# Solution
Add a simple root endpoint so DNS keeps finding APRb 👀 