### PR TITLE
Switch to use routing keys

### DIFF
--- a/lib/aprb.ex
+++ b/lib/aprb.ex
@@ -8,7 +8,7 @@ defmodule Aprb do
 
     children = [
       supervisor(Aprb.Repo, []),
-      worker(Aprb.Service.AmqEventService, [%{topic: "conversations"}], id: :conversations),
+      worker(Aprb.Service.AmqEventService, [%{topic: "conversations", routing_key: "conversation.*"}], id: :conversations),
       worker(Aprb.Service.AmqEventService, [%{topic: "inquiries"}], id: :amq_inquiries),
       worker(Aprb.Service.AmqEventService, [%{topic: "radiation.messages"}], id: :radiation_messages),
       worker(Aprb.Service.AmqEventService, [%{topic: "subscriptions"}], id: :subscriptions),

--- a/lib/views/invoice_slack_view.ex
+++ b/lib/views/invoice_slack_view.ex
@@ -1,8 +1,29 @@
 defmodule Aprb.Views.InvoiceSlackView do
   import Aprb.ViewHelper
 
-  def render(event) do
+  def render(event, routing_key) do
     partner_data = fetch_partner_data(event["properties"]["partner_id"])
+    cond do
+      routing_key =~ "merchant_account" ->
+        merchant_account_message(event, partner_data)
+      true ->
+        invoice_message(event, partner_data)
+    end
+  end
+
+  defp fetch_partner_data(partner_id) do
+    Gravity.get!("/partners/#{partner_id}").body
+  end
+
+  defp merchant_account_message(_event, partner_data) do
+    %{
+      text: ":party-parrot: #{partner_data["name"]} setup merchant account",
+      attachments: [],
+      unfurl_links: true
+    }
+  end
+
+  defp invoice_message(event, partner_data) do
     %{
       text: ":money_with_wings: Invoice #{event["object"]["display"]}",
       attachments: [%{
@@ -26,9 +47,5 @@ defmodule Aprb.Views.InvoiceSlackView do
                     }],
       unfurl_links: true
     }
-  end
-
-  defp fetch_partner_data(partner_id) do
-    Gravity.get!("/partners/#{partner_id}").body
   end
 end

--- a/lib/views/invoice_slack_view.ex
+++ b/lib/views/invoice_slack_view.ex
@@ -15,9 +15,9 @@ defmodule Aprb.Views.InvoiceSlackView do
     Gravity.get!("/partners/#{partner_id}").body
   end
 
-  defp merchant_account_message(_event, partner_data) do
+  defp merchant_account_message(event, partner_data) do
     %{
-      text: ":party-parrot: #{partner_data["name"]} setup merchant account",
+      text: ":party-parrot: #{partner_data["name"]} merchant account #{event["verb"]}",
       attachments: [],
       unfurl_links: true
     }

--- a/test/services/event_service_test.exs
+++ b/test/services/event_service_test.exs
@@ -25,7 +25,7 @@ defmodule Aprb.Service.EventServiceTest do
                   "initial_message_snippet" => "this is a test"
                }
              }
-    response = EventService.process_event(event, "inquiries")
+    response = EventService.process_event(event, "inquiries", "test_routing_key")
     assert response[:text]  == ":shaka: Best inquired on https://www.artsy.net/artwork/artwork_1"
     assert response[:unfurl_links]  == true
   end
@@ -45,7 +45,7 @@ defmodule Aprb.Service.EventServiceTest do
                   }
                }
              }
-    response = EventService.process_event(event, "subscriptions")
+    response = EventService.process_event(event, "subscriptions", "test_routing_key")
     assert response[:text]  == ""
     assert response[:unfurl_links] == false
     attachment = List.first(response[:attachments])
@@ -70,7 +70,7 @@ defmodule Aprb.Service.EventServiceTest do
                   ]
                }
              }
-    response = EventService.process_event(event, "conversations")
+    response = EventService.process_event(event, "conversations", "test_routing_key")
     assert response[:text]  == ":phone: Collector 1 responded on https://www.artsy.net/artwork/artwork-1"
     assert response[:unfurl_links]  == true
     # ignores when outcome wasn't other
@@ -85,7 +85,7 @@ defmodule Aprb.Service.EventServiceTest do
                   "inquiry_id" => "inq1"
                }
              }
-    response = EventService.process_event(event, "conversations")
+    response = EventService.process_event(event, "conversations", "test_routing_key")
     assert response == nil
   end
 
@@ -108,7 +108,7 @@ defmodule Aprb.Service.EventServiceTest do
                 }]
               }
             }
-    response = EventService.process_event(event, "conversations")
+    response = EventService.process_event(event, "conversations", "test_routing_key")
     assert response[:text]  == ":-1: Gallery 1 dismissed Collector One inquiry on https://www.artsy.net/artwork/artwork-1"
     assert response[:unfurl_links] == true
     assert Enum.map(List.first(response[:attachments])[:fields], fn field -> %{String.to_atom(field[:title]) => field[:value]} end) === [%{Outcome: "dont_trust"}, %{Comment: "I really dont"}, %{Radiation: "https://radiation.artsy.net/admin/accounts/2/conversations/rad1"}]


### PR DESCRIPTION
Following up with changes in how we are setting event's `routing_key` in [this impulse PR](https://github.com/artsy/impulse/pull/307) and [changes in lewitt-api](https://github.com/artsy/lewitt-api/pull/254), this PR now:
- listens on proper `routing_key` for `conversations` topic
- now we pass `routing_key` of current event to `EventService.receive_event` so we can render proper message based on routing key
- Added new `merchant_account_message` to `InvoiceSlackView` which we decide if we should use it or not based on new shiny `routing_key`

# NOTE!
This change has to be deployed AFTER two PRs mentioned above are deployed. 