### PR TITLE
Switch to '#' for default routing key

### DIFF
--- a/lib/services/amq_event_service.ex
+++ b/lib/services/amq_event_service.ex
@@ -13,7 +13,7 @@ defmodule Aprb.Service.AmqEventService do
   end
 
   defp rabbitmq_connect(opts) do
-    %{topic: topic, routing_key: routing_key } = Map.merge(%{ routing_key: "*"}, opts)
+    %{topic: topic, routing_key: routing_key } = Map.merge(%{ routing_key: "#"}, opts)
     case Connection.open(Application.get_env(:aprb, RabbitMQ)) do
       {:ok, conn} ->
         # Get notifications when the connection goes down


### PR DESCRIPTION
This took me forever to figure out but listening on `*` means listening on one word routing key, while listening on `#` means listening on everything.

> * (star) can substitute for exactly one word. # (hash) can substitute for zero or more words.

from https://www.rabbitmq.com/tutorials/tutorial-five-python.html