### PR TITLE
proper routing key matching for merchant account events

### DIFF
--- a/lib/views/invoice_slack_view.ex
+++ b/lib/views/invoice_slack_view.ex
@@ -4,7 +4,7 @@ defmodule Aprb.Views.InvoiceSlackView do
   def render(event, routing_key) do
     partner_data = fetch_partner_data(event["properties"]["partner_id"])
     cond do
-      routing_key =~ "merchant_account" ->
+      routing_key =~ "merchantaccount" ->
         merchant_account_message(event, partner_data)
       true ->
         invoice_message(event, partner_data)


### PR DESCRIPTION
The key coming in is `merchantaccount` and not `merchant_account`.