### PR TITLE
Don't show invoice messages when invoice is not sent yet

### DIFF
--- a/lib/views/invoice_slack_view.ex
+++ b/lib/views/invoice_slack_view.ex
@@ -6,7 +6,7 @@ defmodule Aprb.Views.InvoiceSlackView do
     cond do
       routing_key =~ "merchantaccount" ->
         merchant_account_message(event, partner_data)
-      true ->
+      event["sent_at"] != nil ->
         invoice_message(event, partner_data)
     end
   end


### PR DESCRIPTION
# Problem

We are currently post slack messages when invoice is created and when it was sent (1 second after) which is confusing.

# Solution
Filter out invoice creation events and only show sent ones.