### PR TITLE
Add some lightweight sentiment analysis to incoming feedback messages

### DIFF
--- a/lib/services/sentiment_analysis_service.ex
+++ b/lib/services/sentiment_analysis_service.ex
@@ -1,5 +1,4 @@
 defmodule Aprb.Service.SentimentAnalysisService do
-  import Sentient
 
   def sentiment_score(text) do
     Sentient.analyze(text)

--- a/lib/services/sentiment_analysis_service.ex
+++ b/lib/services/sentiment_analysis_service.ex
@@ -1,0 +1,15 @@
+defmodule Aprb.Service.SentimentAnalysisService do
+  import Sentient
+  
+    def sentiment_score(text) do
+      Sentient.analyze(text)
+    end
+  
+    def sentiment_face_emoji(score) do
+      case score do
+        score when score >= 2 -> ":simple_smile:"
+        score when score <= -2 -> ":frowning:"
+        _ -> ":neutral_face:"
+      end
+    end
+end  

--- a/lib/services/sentiment_analysis_service.ex
+++ b/lib/services/sentiment_analysis_service.ex
@@ -1,15 +1,15 @@
 defmodule Aprb.Service.SentimentAnalysisService do
   import Sentient
-  
-    def sentiment_score(text) do
-      Sentient.analyze(text)
+
+  def sentiment_score(text) do
+    Sentient.analyze(text)
+  end
+
+  def sentiment_face_emoji(score) do
+    case score do
+      score when score >= 2 -> ":simple_smile:"
+      score when score <= -2 -> ":frowning:"
+      _ -> ":neutral_face:"
     end
-  
-    def sentiment_face_emoji(score) do
-      case score do
-        score when score >= 2 -> ":simple_smile:"
-        score when score <= -2 -> ":frowning:"
-        _ -> ":neutral_face:"
-      end
-    end
-end  
+  end
+end

--- a/lib/views/feedbacks_slack_view.ex
+++ b/lib/views/feedbacks_slack_view.ex
@@ -1,7 +1,25 @@
 defmodule Aprb.Views.FeedbacksSlackView do
+  import Sentient
+
+  def sentiment_score(message) do
+    Sentient.analyze(message)
+  end
+
+  def sentiment_emoji(score) do
+    case score do
+      score when score >= 2 -> ":simple_smile:"
+      score when score <= -2 -> ":frowning:"
+      _ -> ":neutral_face:"
+    end
+  end
+
+  def prefix(event) do
+    ":artsy-email: (#{sentiment_emoji(sentiment_score(event["properties"]["message"]))})"
+  end
+
   def render(event) do
     %{
-      text: ":artsy-email: #{event["properties"]["user_name"]} <#{event["properties"]["user_email"]}> #{event["verb"]} from #{event["properties"]["url"]}\n\n#{event["properties"]["message"]}",
+      text: "#{prefix(event)} #{event["properties"]["user_name"]} <#{event["properties"]["user_email"]}> #{event["verb"]} from #{event["properties"]["url"]}\n\n#{event["properties"]["message"]}",
       attachments: [],
       unfurl_links: false
     }

--- a/lib/views/feedbacks_slack_view.ex
+++ b/lib/views/feedbacks_slack_view.ex
@@ -1,20 +1,12 @@
 defmodule Aprb.Views.FeedbacksSlackView do
-  import Sentient
-
-  def sentiment_score(message) do
-    Sentient.analyze(message)
-  end
-
-  def sentiment_emoji(score) do
-    case score do
-      score when score >= 2 -> ":simple_smile:"
-      score when score <= -2 -> ":frowning:"
-      _ -> ":neutral_face:"
-    end
-  end
-
+  alias Aprb.Service.SentimentAnalysisService
+  
   def prefix(event) do
-    ":artsy-email: (#{sentiment_emoji(sentiment_score(event["properties"]["message"]))})"
+    emoji = event["properties"]["message"]
+      |>SentimentAnalysisService.sentiment_score
+      |>SentimentAnalysisService.sentiment_face_emoji
+
+      ":artsy-email: (#{emoji})"
   end
 
   def render(event) do

--- a/lib/views/feedbacks_slack_view.ex
+++ b/lib/views/feedbacks_slack_view.ex
@@ -1,12 +1,15 @@
 defmodule Aprb.Views.FeedbacksSlackView do
   alias Aprb.Service.SentimentAnalysisService
-  
-  def prefix(event) do
-    emoji = event["properties"]["message"]
-      |>SentimentAnalysisService.sentiment_score
-      |>SentimentAnalysisService.sentiment_face_emoji
 
-      ":artsy-email: (#{emoji})"
+  def emoji(message) do
+    message
+      |> SentimentAnalysisService.sentiment_score
+      |> SentimentAnalysisService.sentiment_face_emoji
+  end
+
+  def prefix(event) do
+    message = event["properties"]["message"]
+    ":artsy-email: #{emoji(message)}"
   end
 
   def render(event) do

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,8 @@ defmodule Aprb.Mixfile do
       {:ecto, "~> 2.0.0"},
       {:money, "~> 1.1.0"},
       {:calendar, "~> 0.17.2"},
-      {:ex_machina, "~> 1.0", only: :test} ]
+      {:ex_machina, "~> 1.0", only: :test},
+      {:sentient, git: "https://github.com/rdalin82/sentient.git"} ]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]

--- a/mix.lock
+++ b/mix.lock
@@ -25,6 +25,7 @@
   "postgrex": {:hex, :postgrex, "0.12.1", "2f8b46cb3a44dcd42f42938abedbfffe7e103ba4ce810ccbeee8dcf27ca0fb06", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}, {:db_connection, "~> 1.0-rc.4", [hex: :db_connection, optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]},
   "rabbit_common": {:hex, :rabbit_common, "3.6.10", "2217845381350258c5714c22905ec197af0c4dd38eb3b6a5ddbf55c5bd93f127", [:make, :rebar3], []},
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], []},
+  "sentient": {:git, "https://github.com/rdalin82/sentient.git", "ab1b4a6344d44b6e7011ee25dfc259d14db093fc", []},
   "slack": {:hex, :slack, "0.11.0", "9353db9fe2ad9de2222862361869f214dfc8d2dfb793d056fdfbf3c43ce9a244", [:mix], [{:exjsx, "~> 3.2.0", [hex: :exjsx, optional: false]}, {:httpoison, "~> 0.11", [hex: :httpoison, optional: false]}, {:websocket_client, "~> 1.1.0", [hex: :websocket_client, optional: false]}]},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
   "tzdata": {:hex, :tzdata, "0.5.12", "1c17b68692c6ba5b6ab15db3d64cc8baa0f182043d5ae9d4b6d35d70af76f67b", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, optional: false]}]},

--- a/test/services/event_service_test.exs
+++ b/test/services/event_service_test.exs
@@ -127,7 +127,7 @@ defmodule Aprb.Service.EventServiceTest do
               }
             }
     response = EventService.process_event(event, "feedbacks", "test_routing_key")
-    assert response[:text]  == ":artsy-email: User 1 <user@example.com> submitted from /user/delete\n\nThanks"
+    assert response[:text]  == ":artsy-email: (:simple_smile:) User 1 <user@example.com> submitted from /user/delete\n\nThanks"
 
     # for logged out users, subject is nil
     event = %{
@@ -142,6 +142,6 @@ defmodule Aprb.Service.EventServiceTest do
       }
     }
     response = EventService.process_event(event, "feedbacks", "test_routing_key")
-    assert response[:text]  == ":artsy-email: User 1 <user@example.com> submitted from /user/delete\n\nThanks"
+    assert response[:text]  == ":artsy-email: (:simple_smile:) User 1 <user@example.com> submitted from /user/delete\n\nThanks"
   end
 end

--- a/test/services/event_service_test.exs
+++ b/test/services/event_service_test.exs
@@ -114,34 +114,37 @@ defmodule Aprb.Service.EventServiceTest do
     assert Enum.map(List.first(response[:attachments])[:fields], fn field -> %{String.to_atom(field[:title]) => field[:value]} end) === [%{Outcome: "dont_trust"}, %{Comment: "I really dont"}, %{Radiation: "https://radiation.artsy.net/admin/accounts/2/conversations/rad1"}]
   end
 
-  test "process_event: feedbacks" do
-    event = %{
-              "subject" => %{"display" => "User 1 <user@example.com>"},
-              "object" => %{"id" => "1"},
-              "verb" => "submitted",
-              "properties" => %{
-                "user_email" => "user@example.com",
-                "user_name" => "User 1",
-                "url" => "/user/delete",
-                "message" => "Thanks"
-              }
-            }
-    response = EventService.process_event(event, "feedbacks", "test_routing_key")
-    assert response[:text]  == ":artsy-email: (:simple_smile:) User 1 <user@example.com> submitted from /user/delete\n\nThanks"
-
-    # for logged out users, subject is nil
-    event = %{
-      "subject" => nil,
-      "object" => %{"id" => "1"},
-      "verb" => "submitted",
-      "properties" => %{
-        "user_email" => "user@example.com",
-        "user_name" => "User 1",
-        "url" => "/user/delete",
-        "message" => "Thanks"
+  describe "process_event: feedbacks" do
+    test "with a logged in user" do
+      event = %{
+        "subject" => %{"display" => "User 1 <user@example.com>"},
+        "object" => %{"id" => "1"},
+        "verb" => "submitted",
+        "properties" => %{
+          "user_email" => "user@example.com",
+          "user_name" => "User 1",
+          "url" => "/user/delete",
+          "message" => "Thanks"
+        }
       }
-    }
-    response = EventService.process_event(event, "feedbacks", "test_routing_key")
-    assert response[:text]  == ":artsy-email: (:simple_smile:) User 1 <user@example.com> submitted from /user/delete\n\nThanks"
+      response = EventService.process_event(event, "feedbacks", "test_routing_key")
+      assert response[:text]  == ":artsy-email: :simple_smile: User 1 <user@example.com> submitted from /user/delete\n\nThanks"
+    end
+
+    test "without a logged in user" do
+      event = %{
+        "subject" => nil,
+        "object" => %{"id" => "1"},
+        "verb" => "submitted",
+        "properties" => %{
+          "user_email" => "user@example.com",
+          "user_name" => "User 1",
+          "url" => "/user/delete",
+          "message" => "Thanks"
+        }
+      }
+      response = EventService.process_event(event, "feedbacks", "test_routing_key")
+      assert response[:text]  == ":artsy-email: :simple_smile: User 1 <user@example.com> submitted from /user/delete\n\nThanks"
+    end
   end
 end

--- a/test/services/sentiment_analysis_service_test.exs
+++ b/test/services/sentiment_analysis_service_test.exs
@@ -1,7 +1,7 @@
 defmodule Aprb.Service.SentimentAnalysisServiceTest do
   use ExUnit.Case, async: true
   alias Aprb.{Repo, Service.SentimentAnalysisService}
-  
+
   setup do
     Ecto.Adapters.SQL.Sandbox.checkout(Repo)
     Ecto.Adapters.SQL.Sandbox.mode(Aprb.Repo, { :shared, self() })
@@ -24,5 +24,4 @@ defmodule Aprb.Service.SentimentAnalysisServiceTest do
       assert response == ":simple_smile:"
     end
   end
-
 end

--- a/test/services/sentiment_analysis_service_test.exs
+++ b/test/services/sentiment_analysis_service_test.exs
@@ -1,0 +1,28 @@
+defmodule Aprb.Service.SentimentAnalysisServiceTest do
+  use ExUnit.Case, async: true
+  alias Aprb.{Repo, Service.SentimentAnalysisService}
+  
+  setup do
+    Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(Aprb.Repo, { :shared, self() })
+    :ok
+  end
+
+  describe "SentimentAnalysisServiceTest.sentiment_face_emoji/1" do
+    test "with a low score" do
+      response = SentimentAnalysisService.sentiment_face_emoji(-5)
+      assert response == ":frowning:"
+    end
+
+    test "with a neutral score" do
+      response = SentimentAnalysisService.sentiment_face_emoji(0)
+      assert response == ":neutral_face:"
+    end
+
+    test "with a high score" do
+      response = SentimentAnalysisService.sentiment_face_emoji(5)
+      assert response == ":simple_smile:"
+    end
+  end
+
+end


### PR DESCRIPTION
This imports the [Sentient](https://github.com/dantame/sentient) library into APRb in order to do some rudimentary sentiment analysis on incoming feedback messages.

This performs the analysis inline, based on some simple static text analysis and might be improved by calling out to a sentiment analysis API.