### PR TITLE
Filter out email addresses from the Slack view

### DIFF
--- a/lib/views/feedbacks_slack_view.ex
+++ b/lib/views/feedbacks_slack_view.ex
@@ -12,9 +12,13 @@ defmodule Aprb.Views.FeedbacksSlackView do
     ":artsy-email: #{emoji(message)}"
   end
 
+  def obfuscate_emails(message) do
+    String.replace(message, ~r/(\S+)@\S+/m, "\\1[@domain]", global: true)
+  end
+
   def render(event) do
     %{
-      text: "#{prefix(event)} #{event["properties"]["user_name"]} <#{event["properties"]["user_email"]}> #{event["verb"]} from #{event["properties"]["url"]}\n\n#{event["properties"]["message"]}",
+      text: "#{prefix(event)} #{event["properties"]["user_name"]} #{event["verb"]} from #{event["properties"]["url"]}\n\n#{obfuscate_emails event["properties"]["message"]}",
       attachments: [],
       unfurl_links: false
     }

--- a/test/services/event_service_test.exs
+++ b/test/services/event_service_test.exs
@@ -128,7 +128,7 @@ defmodule Aprb.Service.EventServiceTest do
         }
       }
       response = EventService.process_event(event, "feedbacks", "test_routing_key")
-      assert response[:text]  == ":artsy-email: :simple_smile: User 1 <user@example.com> submitted from /user/delete\n\nThanks"
+      assert response[:text]  == ":artsy-email: :simple_smile: User 1 submitted from /user/delete\n\nThanks"
     end
 
     test "without a logged in user" do
@@ -144,7 +144,23 @@ defmodule Aprb.Service.EventServiceTest do
         }
       }
       response = EventService.process_event(event, "feedbacks", "test_routing_key")
-      assert response[:text]  == ":artsy-email: :simple_smile: User 1 <user@example.com> submitted from /user/delete\n\nThanks"
+      assert response[:text]  == ":artsy-email: :simple_smile: User 1 submitted from /user/delete\n\nThanks"
+    end
+
+    test "with a message containing email addresses" do
+      event = %{
+        "subject" => nil,
+        "object" => %{"id" => "1"},
+        "verb" => "submitted",
+        "properties" => %{
+          "user_email" => "user@example.com",
+          "user_name" => "User 1",
+          "url" => "/user/delete",
+          "message" => "I wrote to help@artsy.biz and someone.else@somewhere.com and no luck"
+        }
+      }
+      response = EventService.process_event(event, "feedbacks", "test_routing_key")
+      assert response[:text]  == ":artsy-email: :simple_smile: User 1 submitted from /user/delete\n\nI wrote to help[@domain] and someone.else[@domain] and no luck"
     end
   end
 end


### PR DESCRIPTION
Closes #108 

In order to address concerns about email addresses being exposed / responded to, we now:

- no longer show the sender's email address (which also takes care of the annoying empty `<>` in the case of user deletion messages).

- obfuscate any other email addresses that appear in the message body

