### PR TITLE
Add Admin to purchase events

### DIFF
--- a/lib/views/purchase_slack_view.ex
+++ b/lib/views/purchase_slack_view.ex
@@ -22,8 +22,13 @@ defmodule Aprb.Views.PurchaseSlackView do
                           short: true
                         },
                         %{
-                          title: "Admin",
+                          title: "Outreach Admin",
                           value: "#{event["properties"]["partner"]["outreach_admin"]}",
+                          short: true
+                        },
+                        %{
+                          title: "Admin",
+                          value: "#{event["properties"]["partner"]["admin"]["name"]}",
                           short: true
                         }
                       ]


### PR DESCRIPTION
Following request for adding admins to purchase slack messages and https://github.com/artsy/gravity/pull/11544