### PR TITLE
Add listening on sales events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ vagrant-*.json
 *.tfstate.*.backup
 *.tfplan
 terraform/crash.log
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM elixir:1.5.0
+FROM elixir:1.5.0-slim
 
 # Set up deploy user and working directory
 RUN adduser --disabled-password --gecos '' deploy
 
 RUN apt-get update && \
-      apt-get -y install sudo
+      apt-get -y install sudo git
 
 # Set up working directory
 RUN mkdir /app

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,10 +1,13 @@
 use Mix.Config
 
 config :slack, api_token: System.get_env("SLACK_API_TOKEN")
+
 config :aprb, ecto_repos: [Aprb.Repo]
+
 config :aprb,
   gravity_api_url: System.get_env("GRAVITY_API_URL"),
   gravity_api_token: System.get_env("GRAVITY_API_TOKEN")
+
 config :aprb, RabbitMQ,
   username: System.get_env("RABBITMQ_USER"),
   password: System.get_env("RABBITMQ_PASSWORD"),

--- a/lib/aprb.ex
+++ b/lib/aprb.ex
@@ -14,6 +14,7 @@ defmodule Aprb do
       worker(Aprb.Service.AmqEventService, [%{topic: "subscriptions"}], id: :subscriptions),
       worker(Aprb.Service.AmqEventService, [%{topic: "auctions", routing_keys: ["SecondPriceBidPlaced"]}], id: :auctions),
       worker(Aprb.Service.AmqEventService, [%{topic: "purchases"}], id: :purchases),
+      worker(Aprb.Service.AmqEventService, [%{topic: "sales"}], id: :sales),
       worker(Aprb.Service.AmqEventService, [%{topic: "invoices"}], id: :invoices),
       worker(Aprb.Service.AmqEventService, [%{topic: "consignments"}], id: :consignments),
       worker(Aprb.Service.AmqEventService, [%{topic: "feedbacks"}], id: :feedbacks),

--- a/lib/helpers/view_helper.ex
+++ b/lib/helpers/view_helper.ex
@@ -15,14 +15,18 @@ defmodule Aprb.ViewHelper do
     "https://impulse.artsy.net/#{path}"
   end
 
+  def sale_link(path) do
+    "https://sales.artsy.net/sales/#{path}"
+  end
+
   def radiation_conversation_link(conversation_id) do
     conversation_path = "admin/accounts/2/conversations/#{conversation_id}"
-    radiation_link(conversation_path)
+    "<#{radiation_link(conversation_path)}|Conversation(#{conversation_id})>"
   end
 
   def impulse_conversation_link(conversation_id) do
     conversation_path = "admin/conversations/#{conversation_id}"
-    impulse_link(conversation_path)
+    "<#{impulse_link(conversation_path)}|Conversation(#{conversation_id})>"
   end
 
   def admin_partners_link(path) do
@@ -53,7 +57,7 @@ defmodule Aprb.ViewHelper do
 
   def artworks_display_from_artworkgroups(artworkgroups) do
     artworkgroups
-      |> Enum.map(fn(ag) -> "#{ag["title"]} (#{ag["artists"]})" end)
+      |> Enum.map(fn(ag) -> "<#{artwork_link(ag["id"])}|#{ag["title"]} (#{ag["artists"]})>" end)
       |> Enum.join(", ")
   end
 end

--- a/lib/services/event_service.ex
+++ b/lib/services/event_service.ex
@@ -34,6 +34,8 @@ defmodule Aprb.Service.EventService do
         Aprb.Views.ConsignmentsSlackView.render(event)
       "feedbacks" ->
         Aprb.Views.FeedbacksSlackView.render(event)
+      "sales" ->
+        Aprb.Views.SalesSlackView.render(event, routing_key)
     end
   end
 

--- a/lib/services/summary_service.ex
+++ b/lib/services/summary_service.ex
@@ -6,7 +6,7 @@ defmodule Aprb.Service.SummaryService do
   def update_summary(topic, event) do
     current_date = Calendar.Date.today! "America/New_York"
     cond do
-      Enum.member?(~w(users inquiries purchases conversations radiation.messages invoices consignments feedbacks), topic.name) ->
+      Enum.member?(~w(users inquiries purchases conversations radiation.messages invoices consignments feedbacks sales), topic.name) ->
         handle_summary(topic, event["verb"], current_date)
       Enum.member?(~w(subscriptions), topic.name) ->
         handle_summary(topic, SubscriptionHelper.parsed_verb(event), current_date)

--- a/lib/views/sales_slack_view.ex
+++ b/lib/views/sales_slack_view.ex
@@ -1,0 +1,36 @@
+defmodule Aprb.Views.SalesSlackView do
+  import Aprb.ViewHelper
+  def render(event, routing_key) do
+    case routing_key do
+      "sale.started" ->
+        %{
+          text: ":gavel: :star: ted: <#{sale_link(event["properties"]["id"])}|#{event["properties"]["name"]}>",
+          attachments: sale_attachments(event),
+          unfurl_links: false
+        }
+      "sale.ended" ->
+        %{
+          text: ":gavel: :shaka: : ended: <#{sale_link(event["properties"]["id"])}|#{event["properties"]["name"]}>",
+          attachments: sale_attachments(event),
+          unfurl_links: false
+        }
+    end
+  end
+
+  defp sale_attachments(event) do
+    [%{
+      fields: [
+        %{
+          title: "Sale Code",
+          value: "#{event["properties"]["sale_code"]}",
+          short: true
+        },
+        %{
+          title: "Description",
+          value: "#{event["properties"]["description"]}",
+          short: false
+        }
+      ]
+    }]
+  end
+end

--- a/priv/repo/migrations/20180713162611_add_sales_topic.exs
+++ b/priv/repo/migrations/20180713162611_add_sales_topic.exs
@@ -1,0 +1,10 @@
+defmodule Aprb.Repo.Migrations.AddSalesTopic do
+  use Ecto.Migration
+
+  alias Aprb.{Repo,Topic}
+
+  def change do
+    changeset = Topic.changeset(%Topic{}, %{name: "sales"})
+    Repo.insert!(changeset)
+  end
+end

--- a/test/services/event_service_test.exs
+++ b/test/services/event_service_test.exs
@@ -1,13 +1,7 @@
 defmodule Aprb.Service.EventServiceTest do
-  use ExUnit.Case, async: false
+  use Aprb.ServiceCase
   import Aprb.Factory
   alias Aprb.{Repo, Service.EventService}
-
-  setup do
-    Ecto.Adapters.SQL.Sandbox.checkout(Repo)
-    Ecto.Adapters.SQL.Sandbox.mode(Aprb.Repo, { :shared, self() })
-    :ok
-  end
 
   test "slack_message: inquiries" do
     insert(:topic, name: "inquiries")
@@ -165,7 +159,6 @@ defmodule Aprb.Service.EventServiceTest do
   end
 
   test "slack_message: sale.started" do
-    insert(:topic, name: "sales")
     event = %{
                "verb" => "started",
                "properties" => %{
@@ -176,21 +169,6 @@ defmodule Aprb.Service.EventServiceTest do
              }
     response = EventService.slack_message(event, "sales", "sale.started")
     assert response[:text]  == ":gavel: :star: ted: <https://sales.artsy.net/sales/sale1|pretty cool sale>"
-    assert response[:unfurl_links]  == false
-  end
-
-  test "slack_message: sale.ended" do
-    insert(:topic, name: "sales")
-    event = %{
-               "verb" => "ended",
-               "properties" => %{
-                  "id" => "sale1",
-                  "name" => "pretty cool sale",
-                  "description" => "name is descriptive enough!"
-               }
-             }
-    response = EventService.slack_message(event, "sales", "sale.ended")
-    assert response[:text] == ":gavel: :shaka: : ended: <https://sales.artsy.net/sales/sale1|pretty cool sale>"
     assert response[:unfurl_links]  == false
   end
 end

--- a/test/services/event_service_test.exs
+++ b/test/services/event_service_test.exs
@@ -111,7 +111,7 @@ defmodule Aprb.Service.EventServiceTest do
     response = EventService.slack_message(event, "conversations", "test_routing_key")
     assert response[:text]  == ":-1: Gallery 1 dismissed Collector One inquiry on https://www.artsy.net/artwork/artwork-1"
     assert response[:unfurl_links] == true
-    assert Enum.map(List.first(response[:attachments])[:fields], fn field -> %{String.to_atom(field[:title]) => field[:value]} end) === [%{Outcome: "dont_trust"}, %{Comment: "I really dont"}, %{Radiation: "https://radiation.artsy.net/admin/accounts/2/conversations/rad1"}]
+    assert Enum.map(List.first(response[:attachments])[:fields], fn field -> %{String.to_atom(field[:title]) => field[:value]} end) === [%{Outcome: "dont_trust"}, %{Comment: "I really dont"}, %{Radiation: "<https://radiation.artsy.net/admin/accounts/2/conversations/rad1|Conversation(rad1)>"}]
   end
 
   describe "slack_message: feedbacks" do
@@ -162,5 +162,35 @@ defmodule Aprb.Service.EventServiceTest do
       response = EventService.slack_message(event, "feedbacks", "test_routing_key")
       assert response[:text]  == ":artsy-email: :simple_smile: User 1 submitted from /user/delete\n\nI wrote to help[@domain] and someone.else[@domain] and no luck"
     end
+  end
+
+  test "slack_message: sale.started" do
+    insert(:topic, name: "sales")
+    event = %{
+               "verb" => "started",
+               "properties" => %{
+                  "id" => "sale1",
+                  "name" => "pretty cool sale",
+                  "description" => "name is descriptive enough!"
+               }
+             }
+    response = EventService.slack_message(event, "sales", "sale.started")
+    assert response[:text]  == ":gavel: :star: ted: <https://sales.artsy.net/sales/sale1|pretty cool sale>"
+    assert response[:unfurl_links]  == false
+  end
+
+  test "slack_message: sale.ended" do
+    insert(:topic, name: "sales")
+    event = %{
+               "verb" => "ended",
+               "properties" => %{
+                  "id" => "sale1",
+                  "name" => "pretty cool sale",
+                  "description" => "name is descriptive enough!"
+               }
+             }
+    response = EventService.slack_message(event, "sales", "sale.ended")
+    assert response[:text] == ":gavel: :shaka: : ended: <https://sales.artsy.net/sales/sale1|pretty cool sale>"
+    assert response[:unfurl_links]  == false
   end
 end

--- a/test/support/service_case.ex
+++ b/test/support/service_case.ex
@@ -1,0 +1,53 @@
+defmodule Aprb.ServiceCase do
+  @moduledoc """
+  This module defines the setup for tests requiring
+  access to the application's service layer.
+
+  You may define functions here to be used as helpers in
+  your tests.
+
+  Finally, if the test case interacts with the database,
+  it cannot be async. For this reason, every test runs
+  inside a transaction which is reset at the beginning
+  of the test unless the test case is marked as async.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      alias Aprb.Repo
+
+      import Ecto
+      import Ecto.Changeset
+      import Ecto.Query
+      import Aprb.ServiceCase
+    end
+  end
+
+  setup tags do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Aprb.Repo)
+
+    unless tags[:async] do
+      Ecto.Adapters.SQL.Sandbox.mode(Aprb.Repo, {:shared, self()})
+    end
+
+    :ok
+  end
+
+  @doc """
+  A helper that transform changeset errors to a map of messages.
+
+      assert {:error, changeset} = Accounts.create_user(%{password: "short"})
+      assert "password is too short" in errors_on(changeset).password
+      assert %{password: ["password is too short"]} = errors_on(changeset)
+
+  """
+  def errors_on(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {message, opts} ->
+      Enum.reduce(opts, message, fn {key, value}, acc ->
+        String.replace(acc, "%{#{key}}", to_string(value))
+      end)
+    end)
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,3 +5,5 @@ Application.ensure_all_started(:plug)
 Logger.configure(level: :error)
 ExUnit.configure seed: elem(:os.timestamp, 2)
 ExUnit.start()
+
+Ecto.Adapters.SQL.Sandbox.mode(Aprb.Repo, {:shared, self()})


### PR DESCRIPTION
# Changes
- Adds listening on new `sales` topic
- Post slack messages for `sale.ended` and `sale.started` events.

# Cleanups
Used Slack's `<url|title>` approach to remove some long ur's and make them actual links.