### PR TITLE
Add sale type and number of lots

### DIFF
--- a/lib/views/sales_slack_view.ex
+++ b/lib/views/sales_slack_view.ex
@@ -1,23 +1,24 @@
 defmodule Aprb.Views.SalesSlackView do
   import Aprb.ViewHelper
   def render(event, routing_key) do
+    sale = fetch_sale(event["properties"]["id"])
     case routing_key do
       "sale.started" ->
         %{
           text: ":gavel: :star: ted: <#{artsy_sale_link(event["properties"]["id"])}|#{event["properties"]["name"]}>",
-          attachments: sale_attachments(event),
+          attachments: sale_attachments(event, sale),
           unfurl_links: true
         }
       "sale.ended" ->
         %{
           text: ":gavel: :shaka: : ended: <#{artsy_sale_link(event["properties"]["id"])}|#{event["properties"]["name"]}>",
-          attachments: sale_attachments(event),
+          attachments: sale_attachments(event, sale),
           unfurl_links: true
         }
     end
   end
 
-  defp sale_attachments(event) do
+  defp sale_attachments(event, sale) do
     [%{
       fields: [
         %{
@@ -29,8 +30,26 @@ defmodule Aprb.Views.SalesSlackView do
           title: "Admin Link",
           value: ohm_sale_link(event["properties"]["id"]),
           short: true
-        }
+        },
+        %{
+          title: "Sale Type",
+          value: sale[:sale_type],
+          short: true
+        },
+        %{
+          title: "Eligible Lots",
+          value: sale[:eligible_sale_artworks_count],
+          short: true
+        },
       ]
     }]
+  end
+
+  defp fetch_sale(sale_id) do
+    sale_response = Gravity.get!("/v1/sale/shared-online-only-mocktion-k8s").body
+    %{
+      sale_type: sale_response["sale_type"],
+      eligible_sale_artworks_count: sale_response["eligible_sale_artworks_count"],
+    }
   end
 end


### PR DESCRIPTION
Fetch `sale` endpoint and get number of lots and sale type to show in the notification