### PR TITLE
Fix invoice message issue and missing artwork links

### DIFF
--- a/lib/views/commerce_slack_view.ex
+++ b/lib/views/commerce_slack_view.ex
@@ -111,12 +111,7 @@ defmodule Aprb.Views.CommerceSlackView do
         title: "Seller",
         value: seller["name"],
         short: true
-      },
-      %{
-        title: "Artworks",
-        value: artworks_links_from_line_items(event["properties"]["line_items"]),
-        short: false
-      },
+      }
     ]
   end
 
@@ -130,6 +125,6 @@ defmodule Aprb.Views.CommerceSlackView do
   defp artworks_links_from_line_items(line_items) do
     line_items
       |> Enum.map(fn(li) -> artwork_link(li["artwork_id"]) end)
-      |> Enum.map(fn(artwork_link) -> "<#{artwork_link} | >" end)
+      |> Enum.map(fn(artwork_link) -> "<#{artwork_link}| >" end)
   end
 end

--- a/lib/views/invoice_slack_view.ex
+++ b/lib/views/invoice_slack_view.ex
@@ -91,7 +91,7 @@ defmodule Aprb.Views.InvoiceSlackView do
 
   defp artworks_display_from_artworkgroups(artworkgroups) do
     artworkgroups
-      |> Enum.map(fn(ag) -> "<#{artwork_link(ag["id"])}|#{ag["title"]} (#{ag["artists"]})>" end)
+      |> Enum.map(fn(ag) -> "<#{artwork_link(ag["artwork_id"])}|#{ag["title"]} (#{ag["artists"]})>" end)
       |> Enum.join(", ")
   end
 end


### PR DESCRIPTION
# Problem
Followup on #145 , artworks links are not unfurled in commerce messages.
also fixes https://github.com/artsy/aprb/issues/129

# Cause
Artwork links have extra space in them causing unfurl not to work.
Invoice message issue's cause is we where getting `id` from `artwork_group` but had to get `artwork_id`

