### PR TITLE
Fix CAO and sign showing as 1 in the messages

### DIFF
--- a/lib/views/consignments_slack_view.ex
+++ b/lib/views/consignments_slack_view.ex
@@ -39,12 +39,12 @@ defmodule Aprb.Views.ConsignmentsSlackView do
                         },
                         %{
                           title: "Signed",
-                          value: event["properties"]["signature"],
+                          value: "#{event["properties"]["signature"]}",
                           short: true
                         },
                         %{
                           title: "COA",
-                          value: event["properties"]["authenticity_certificate"],
+                          value: "#{event["properties"]["authenticity_certificate"]}",
                           short: true
                         },
                         %{


### PR DESCRIPTION
# Problem
After changes in #150 , we switched to send `sign` and `coa` flags directly in the hash instead of their string representations. Slack seems to change booleans to 0/1 in their message attachments.

# Change 
Switch back to string for those 2 fields.