### PR TITLE
Add available purchase types per line item

### DIFF
--- a/lib/api/root.ex
+++ b/lib/api/root.ex
@@ -11,7 +11,7 @@ defmodule Aprb.Api.Root do
   mount Aprb.Api.Ping
   mount Aprb.Api.Slack
 
-  rescue_from Aprb.Api.Errors.Unauthorized, as: e do
+  rescue_from Aprb.Api.Errors.Unauthorized do
     conn
     |> put_status(401)
     |> text("Unauthorized")


### PR DESCRIPTION
# Problem
We want to show available purchase options for each artwork in the order and also show what type or purchase option we got.

# Solution
Do it!

# Selfie

![selfie-0](https://i.imgur.com/G2z2eI9.gif)
[_GitHub Selfies_](https://github.com/thieman/github-selfies/)
