### PR TITLE
Use ecommerce and offer flag instead of offerable

### DIFF
--- a/lib/views/commerce_slack_view.ex
+++ b/lib/views/commerce_slack_view.ex
@@ -200,9 +200,9 @@ defmodule Aprb.Views.CommerceSlackView do
         %{
           title: "Available Purchase Modes",
           value: cond do
-                    artwork["acquireable"] && artwork["offerable"] -> "BNMO"
-                    artwork["acquireable"] -> "BN"
-                    artwork["offerable"] -> "MO"
+                    artwork["ecommerce"] && artwork["offer"] -> "BNMO"
+                    artwork["ecommerce"] -> "BN"
+                    artwork["offer"] -> "MO"
                     true -> "!?"
                  end,
           short: true


### PR DESCRIPTION
# Problem
When showing available purchase options if artwork is not available for sale anymore we don't show purchase options available at the time of purchase.

# Fix
Instead of using `offerable` and `aqucialitelkwjklaable` (i can't spell this one), use `offer` and `ecommerce` flag of the artwork

![selfie-0](https://i.imgur.com/7LxEmmF.png)
[_GitHub Selfies_](https://github.com/thieman/github-selfies/)
