### PR TITLE
Add mode to transaction events

### DIFF
--- a/lib/views/commerce/commerce_transaction_view.ex
+++ b/lib/views/commerce/commerce_transaction_view.ex
@@ -7,6 +7,11 @@ defmodule Aprb.Views.CommerceTransactionSlackView do
       attachments: [%{
         fields: [
           %{
+            title: "Mode",
+            value: event["properties"]["order"]["mode"],
+            short: true
+          },
+          %{
             title: "Failure Code",
             value: event["properties"]["failure_code"],
             short: true


### PR DESCRIPTION
Per CRT's request, they want to know when a failed transaction happens was it BN or MO