### PR TITLE
Support other currencies and fix weird divide by 100

### DIFF
--- a/lib/helpers/view_helper.ex
+++ b/lib/helpers/view_helper.ex
@@ -74,7 +74,7 @@ defmodule Aprb.ViewHelper do
 
   def format_price(price, currency \\ :USD, symbol \\ true) do
     if price do
-      Money.to_string(Money.new(round(price * 100), currency), symbol: symbol)
+      Money.to_string(Money.new(round(price), currency), symbol: symbol)
     else
       "N/A"
     end

--- a/lib/views/bidding_slack_view.ex
+++ b/lib/views/bidding_slack_view.ex
@@ -11,7 +11,7 @@ defmodule Aprb.Views.BiddingSlackView do
                       fields: [
                         %{
                           title: "Amount",
-                          value: format_price(event["amountCents"] / 100, artwork_data[:currency]),
+                          value: format_price(event["amountCents"], artwork_data[:currency]),
                           short: true
                         },
                         %{
@@ -44,21 +44,20 @@ defmodule Aprb.Views.BiddingSlackView do
     }
   end
 
-  @spec estimate_field_value(nil | bitstring() | integer()) :: nil | float()
-  def estimate_field_value(nil), do: nil
-  def estimate_field_value(value) when is_integer(value), do: value / 100
-  def estimate_field_value(value) when is_bitstring(value), do: String.to_integer(value) / 100
+  @spec field_value_to_i(nil | bitstring() | integer()) :: nil | integer()
+  def field_value_to_i(nil), do: nil
+  def field_value_to_i(value) when is_integer(value), do: value
+  def field_value_to_i(value) when is_bitstring(value), do: field_value_to_i(String.to_integer(value))
 
   defp fetch_sale_artwork(lot_id) do
     sale_artwork_response = @gravity_api.get!("/sale_artworks/#{lot_id}").body
-    IO.puts(sale_artwork_response["currency"])
     %{
       permalink: sale_artwork_response["_links"]["permalink"]["href"],
       lot_number: sale_artwork_response["lot_number"],
       currency: sale_artwork_response["currency"],
-      estimate_cents: estimate_field_value(sale_artwork_response["estimate_cents"]),
-      high_estimate_cents: estimate_field_value(sale_artwork_response["high_estimate_cents"]),
-      low_estimate_cents: estimate_field_value(sale_artwork_response["low_estimate_cents"])
+      estimate_cents: field_value_to_i(sale_artwork_response["estimate_cents"]),
+      high_estimate_cents: field_value_to_i(sale_artwork_response["high_estimate_cents"]),
+      low_estimate_cents: field_value_to_i(sale_artwork_response["low_estimate_cents"])
     }
   end
 end

--- a/lib/views/commerce/commerce_offer_slack_view.ex
+++ b/lib/views/commerce/commerce_offer_slack_view.ex
@@ -28,7 +28,7 @@ defmodule Aprb.Views.CommerceOfferSlackView do
           fields: [
             %{
               title: "Offer Amount",
-              value: format_price(event["properties"]["amount_cents"] / 100),
+              value: format_price(event["properties"]["amount_cents"], event["properties"]["order"]["currency_code"]),
               short: true
             },
             %{
@@ -38,7 +38,7 @@ defmodule Aprb.Views.CommerceOfferSlackView do
             },
             %{
               title: "List Price",
-              value: format_price(event["properties"]["order"]["total_list_price_cents"] / 100),
+              value: format_price(event["properties"]["order"]["total_list_price_cents"], event["properties"]["order"]["currency_code"]),
               short: true
             },
             %{
@@ -74,7 +74,7 @@ defmodule Aprb.Views.CommerceOfferSlackView do
           fields: [
             %{
               title: "Offer Amount",
-              value: format_price(event["properties"]["amount_cents"] / 100),
+              value: format_price(event["properties"]["amount_cents"], event["properties"]["order"]["currency_code"]),
               short: true
             },
             %{
@@ -84,12 +84,12 @@ defmodule Aprb.Views.CommerceOfferSlackView do
             },
             %{
               title: "Counter to",
-              value: format_price(event["properties"]["in_response_to"]["amount_cents"] / 100),
+              value: format_price(event["properties"]["in_response_to"]["amount_cents"], event["properties"]["order"]["currency_code"]),
               short: true
             },
             %{
               title: "List Price",
-              value: format_price(event["properties"]["order"]["total_list_price_cents"] / 100),
+              value: format_price(event["properties"]["order"]["total_list_price_cents"], event["properties"]["order"]["currency_code"]),
               short: true
             },
             %{

--- a/lib/views/commerce/commerce_order_slack_view.ex
+++ b/lib/views/commerce/commerce_order_slack_view.ex
@@ -64,7 +64,7 @@ defmodule Aprb.Views.CommerceOrderSlackView do
   defp append_admin(attachments, nil), do: attachments
   defp append_admin(attachments, admin), do: attachments ++ [%{ title: "Admin", value: admin["name"], short: true}]
 
-  defp append_offer_fields(attachments, "offer", properties), do: attachments ++ [%{title: "List Price", value: format_price(properties["total_list_price_cents"] / 100), short: true}]
+  defp append_offer_fields(attachments, "offer", properties), do: attachments ++ [%{title: "List Price", value: format_price(properties["total_list_price_cents"], properties["currency_code"]), short: true}]
   defp append_offer_fields(attachments, _, _), do: attachments
 
   defp order_attachment_fields(order_properties, _seller, buyer) do
@@ -81,7 +81,7 @@ defmodule Aprb.Views.CommerceOrderSlackView do
       },
       %{
         title: "Total Amount",
-        value: format_price(order_properties["items_total_cents"] / 100),
+        value: format_price(order_properties["items_total_cents"], order_properties["currency_code"]),
         short: true
       }
     ]

--- a/lib/views/commerce/commerce_transaction_slack_view.ex
+++ b/lib/views/commerce/commerce_transaction_slack_view.ex
@@ -58,7 +58,7 @@ defmodule Aprb.Views.CommerceTransactionSlackView do
       },
       %{
         title: "Total Amount",
-        value: format_price(event["properties"]["order"]["items_total_cents"] / 100),
+        value: format_price(event["properties"]["order"]["items_total_cents"], event["properties"]["order"]["currency_code"]),
         short: true
       }
     ]

--- a/lib/views/inquiry_slack_view.ex
+++ b/lib/views/inquiry_slack_view.ex
@@ -8,17 +8,17 @@ defmodule Aprb.Views.InquirySlackView do
                       fields: [
                         %{
                           title: "Professional Buyer?",
-                          value: "#{event["properties"]["inquirer"]["professional_buyer"]}",
+                          value: event["properties"]["inquirer"]["professional_buyer"],
                           short: true
                         },
                         %{
                           title: "Confirmed Buyer?",
-                          value: "#{event["properties"]["inquirer"]["confirmed_buyer"]}",
+                          value: event["properties"]["inquirer"]["confirmed_buyer"],
                           short: true
                         },
                         %{
                           title: "Message Snippet",
-                          value: "#{event["properties"]["initial_message_snippet"]}",
+                          value: event["properties"]["initial_message_snippet"],
                           short: false
                         }
                       ]

--- a/lib/views/invoice_slack_view.ex
+++ b/lib/views/invoice_slack_view.ex
@@ -43,7 +43,7 @@ defmodule Aprb.Views.InvoiceSlackView do
           },
           %{
             title: "Total",
-            value: format_price(event["properties"]["invoice"]["total_cents"] / 100),
+            value: format_price(event["properties"]["invoice"]["total_cents"]),
             short: true
           },
           %{
@@ -72,7 +72,7 @@ defmodule Aprb.Views.InvoiceSlackView do
                         },
                         %{
                           title: "Total",
-                          value: format_price(event["properties"]["total_cents"] / 100),
+                          value: format_price(event["properties"]["total_cents"]),
                           short: true
                         },
                         %{

--- a/lib/views/purchase_slack_view.ex
+++ b/lib/views/purchase_slack_view.ex
@@ -8,27 +8,27 @@ defmodule Aprb.Views.PurchaseSlackView do
                       fields: [
                         %{
                           title: "Price",
-                          value: "#{format_price(event["properties"]["sale_price"] || 0)}",
+                          value: format_price(event["properties"]["sale_price"] || 0 * 100),
                           short: true
                         },
                         %{
                           title: "Partner name",
-                          value: "#{event["properties"]["partner"]["name"]}",
+                          value: event["properties"]["partner"]["name"],
                           short: true
                         },
                         %{
                           title: "Contract Type",
-                          value: "#{event["properties"]["partner"]["contract_type"]}",
+                          value: event["properties"]["partner"]["contract_type"],
                           short: true
                         },
                         %{
                           title: "Outreach Admin",
-                          value: "#{event["properties"]["partner"]["outreach_admin"]}",
+                          value: event["properties"]["partner"]["outreach_admin"],
                           short: true
                         },
                         %{
                           title: "Admin",
-                          value: "#{event["properties"]["partner"]["admin"]["name"]}",
+                          value: event["properties"]["partner"]["admin"]["name"],
                           short: true
                         }
                       ]

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -34,6 +34,7 @@ defmodule Aprb.Fixtures do
         "seller_type" => "gallery",
         "buyer_id" => "user1",
         "buyer_type" => "user",
+        "currency_code" => "USD",
         "items_total_cents" => 2000000,
         "total_list_price_cents" => 3000,
         "line_items" => [
@@ -84,6 +85,7 @@ defmodule Aprb.Fixtures do
           "seller_type" => "gallery",
           "buyer_id" => "user1",
           "buyer_type" => "user",
+          "currency_code" => "USD",
           "items_total_cents" => 2000000,
           "total_list_price_cents" => 3000,
           "line_items" => [

--- a/test/views/commerce/commerce_transaction_slack_view_test.exs
+++ b/test/views/commerce/commerce_transaction_slack_view_test.exs
@@ -6,6 +6,7 @@ defmodule Aprb.Views.CommerceTransactionSlackViewTest do
     event = Aprb.Fixtures.commerce_transaction_event(%{
       "id" => "order123",
       "items_total_cents" => 2000000,
+      "currency_code" => "USD",
       "seller_id" => "partner1",
       "seller_type" => "gallery",
       "buyer_id" => "user1",
@@ -25,6 +26,7 @@ defmodule Aprb.Views.CommerceTransactionSlackViewTest do
     event = Aprb.Fixtures.commerce_transaction_event(%{
       "id" => "order123",
       "items_total_cents" => 2000000,
+      "currency_code" => "USD",
       "seller_id" => "partner1",
       "seller_type" => "gallery",
       "buyer_id" => "user1",
@@ -42,6 +44,7 @@ defmodule Aprb.Views.CommerceTransactionSlackViewTest do
     event = Aprb.Fixtures.commerce_transaction_event(%{
       "id" => "order123",
       "items_total_cents" => 2000000,
+      "currency_code" => "USD",
       "seller_id" => "partner1",
       "seller_type" => "gallery",
       "buyer_id" => "user1",

--- a/test/views/commerce_slack_view_test.exs
+++ b/test/views/commerce_slack_view_test.exs
@@ -6,7 +6,8 @@ defmodule Aprb.Views.CommerceSlackViewTest do
   test "Transaction event renders transaction message" do
     event = Aprb.Fixtures.commerce_transaction_event(%{
       "id" => "order123",
-      "items_total_cents" => 2000000
+      "items_total_cents" => 2000000,
+      "currency_code" => "USD"
     })
     slack_view = CommerceSlackView.render(event, "transaction.failure")
     assert slack_view.text  == ":alert: <https://dashboard.stripe.com/search?query=order123|insufficient_funds>"


### PR DESCRIPTION
# Problem
Current commerce messages show amounts in $ even if it was in GBP.

# Solution
Remove weirdness around `format_price` and how needs things in dollar but then multiplies by 100 and pass `currency_code` to all `format_price` calls.
