### PR TITLE
Use Circle orbs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,12 @@
-version: 2
+version: 2.1
+
+orbs:
+  hokusai: artsy/hokusai@0.7.0
+
 jobs:
   test:
     docker:
-      - image: artsy/hokusai:0.5.4
+      - image: artsy/hokusai
     steps:
       - add_ssh_keys
       - checkout
@@ -16,46 +20,47 @@ jobs:
           command: docker cp hokusai_aprb_1:/app/cover ~/aprb
       - store_artifacts:
           path: ~/aprb/cover
-  push:
-    docker:
-      - image: artsy/hokusai:0.5.4
-    steps:
-      - add_ssh_keys
-      - checkout
-      - setup_remote_docker
-      - run:
-          name: Push
-          command: hokusai registry push --tag $CIRCLE_SHA1 --force --overwrite
-  deploy:
-    docker:
-      - image: artsy/hokusai:0.5.4
-    steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "05:c8:1f:ac:f8:a5:76:0e:d0:2d:52:0d:ef:12:2c:30"
-      - checkout
-      - run:
-          name: Configure
-          command: hokusai configure --kubectl-version 1.10.7 --s3-bucket artsy-citadel --s3-key k8s/config --platform linux
-      - run:
-          name: Deploy
-          command: hokusai staging deploy $CIRCLE_SHA1
+
+not_staging_or_release: &not_staging_or_release
+  filters:
+    branches:
+      ignore:
+        - staging
+        - release
+
+only_master: &only_master
+  context: hokusai
+  filters:
+    branches:
+      only: master
+
+only_release: &only_release
+  context: hokusai
+  filters:
+    branches:
+      only: release
+
 workflows:
-  version: 2
   default:
     jobs:
-      - test
-      - push:
-          context: hokusai
-          filters:
-            branches:
-              only: master
+      # pre-staging
+      - test:
+          name: test
+          <<: *not_staging_or_release
+
+      # staging
+      - hokusai/push:
+          name: push-staging-image
+          <<: *only_master
           requires:
             - test
-      - deploy:
-          context: hokusai
-          filters:
-            branches:
-              only: master
+
+      - hokusai/deploy-staging:
+          <<: *only_master
+          project-name: aprb
           requires:
-            - push
+            - push-staging-image
+
+      # release
+      - hokusai/deploy-production:
+          <<: *only_release

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Aprb is a fairly generic consumer of RabbitMQ events (see [Service.AmqEventServi
 * __State:__ production
 * __Production:__ [http://aprb-production-http-1702133716.us-east-1.elb.amazonaws.com/slack](http://aprb-production-http-1702133716.us-east-1.elb.amazonaws.com/slack)
 * __GitHub:__ [https://github.com/artsy/aprb](https://github.com/artsy/aprb)
-* __CI:__ [https://circleci.com/gh/artsy/aprb](https://circleci.com/gh/artsy/aprb)
-* __Point People:__ [@ashkan18](https://github.com/ashkan18), [@dblock](https://github.com/dblock)
+* __CI/Deploys:__ [CircleCi](https://circleci.com/gh/artsy/aprb); merged PRs to `artsy/aprb#master` are automatically deployed to staging; PRs from `staging` to `release` are automatically deployed to production. [Start a deploy...](https://github.com/artsy/aprb/compare/release...staging?expand=1)
+* __Point People:__ [@ashkan18](https://github.com/ashkan18)
 
 ## Development
 


### PR DESCRIPTION
Updates `push` and `deploy` steps to use orbs, and implement PR-based release process.
Circle config has been updated to use 2.1 features.